### PR TITLE
Added default implementation of Java Nimbus Request objects

### DIFF
--- a/java/build.gradle
+++ b/java/build.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'java-library'
+
+sourceCompatibility = JavaVersion.VERSION_1_8
+targetCompatibility = JavaVersion.VERSION_1_8
+
+dependencies { }

--- a/java/src/main/java/com/adsbynimbus/openrtb/BidRequest.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/BidRequest.java
@@ -36,8 +36,8 @@ public interface BidRequest {
                 public final Device device = (Device) values.get(DEVICE);
                 public final Format format = (Format) values.get(FORMAT);
                 public final User user = (User) values.get(USER);
-                public final int test = (int) (values.containsKey(TEST) ? values.get(TEST) : 0);
-                public final int tmax = (int) (values.containsKey(TIMEOUT) ? values.get(TIMEOUT) : 500);
+                public final Integer test = (Integer) values.get(TEST); // Server default 0
+                public final Integer tmax = (Integer) values.get(TIMEOUT); // Server default 500
                 public final Regs regs = (Regs) values.get(REGS);
                 public final Object ext = values.containsKey(API_KEY) || values.containsKey(SESSION_ID) ?
                         new Object() {

--- a/java/src/main/java/com/adsbynimbus/openrtb/BidRequest.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/BidRequest.java
@@ -1,0 +1,50 @@
+package com.adsbynimbus.openrtb;
+
+import com.adsbynimbus.openrtb.impression.Format;
+import com.adsbynimbus.openrtb.impression.Impression;
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+import com.adsbynimbus.openrtb.publisher.App;
+import com.adsbynimbus.openrtb.user.Device;
+import com.adsbynimbus.openrtb.user.Regs;
+import com.adsbynimbus.openrtb.user.User;
+
+import java.util.Map;
+
+import static com.adsbynimbus.openrtb.impression.Format.FORMAT;
+
+public interface BidRequest {
+
+    String IMP = "imp"; // Impression[] (only size 1 valid)
+    String APP = "app"; // App
+    String DEVICE = "device"; // Device
+    String USER = "user"; // User
+    String TEST = "test"; // int (default 0; 0 = Live, 1 = Test)
+    String TIMEOUT = "tmax"; // int
+    String REGS = "regs";
+
+    //Extensions
+    String API_KEY = "api_key";
+    String SESSION_ID = "session_id";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default BidRequest build() {
+            final Map values = getValues();
+            return new BidRequest() {
+                public final Impression[] imp = (Impression[]) values.get(IMP);
+                public final App app = (App) values.get(APP);
+                public final Device device = (Device) values.get(DEVICE);
+                public final Format format = (Format) values.get(FORMAT);
+                public final User user = (User) values.get(USER);
+                public final int test = (int) (values.containsKey(TEST) ? values.get(TEST) : 0);
+                public final int tmax = (int) (values.containsKey(TIMEOUT) ? values.get(TIMEOUT) : 500);
+                public final Regs regs = (Regs) values.get(REGS);
+                public final Object ext = values.containsKey(API_KEY) || values.containsKey(SESSION_ID) ?
+                        new Object() {
+                            public final String api_key = (String) values.get(API_KEY);
+                            public final String session_id = (String) values.get(SESSION_ID);
+                        } : null;
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Banner.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Banner.java
@@ -1,0 +1,28 @@
+package com.adsbynimbus.openrtb.impression;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+import static com.adsbynimbus.openrtb.impression.Format.FORMAT;
+import static com.adsbynimbus.openrtb.impression.Format.HEIGHT;
+import static com.adsbynimbus.openrtb.impression.Format.WIDTH;
+
+public interface Banner extends BaseCreative {
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Banner build() {
+            final Map values = getValues();
+            return new Banner() {
+                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 2f);
+                public final Format[] format = (Format[]) values.get(FORMAT);
+                public final Integer w = (Integer) values.get(WIDTH);
+                public final Integer h = (Integer) values.get(HEIGHT);
+                public final Integer pos = (Integer) values.get(POSITION);
+                public final String[] mimes = (String[]) values.get(MIME_TYPES);
+                public final int[] api = (int[]) values.get(SUPPORTED_APIS);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Banner.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Banner.java
@@ -15,7 +15,7 @@ public interface Banner extends BaseCreative {
         default Banner build() {
             final Map values = getValues();
             return new Banner() {
-                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 2f);
+                public final Float bidfloor = (Float) values.get(BID_FLOOR); // Server default is 2.0
                 public final Format[] format = (Format[]) values.get(FORMAT);
                 public final Integer w = (Integer) values.get(WIDTH);
                 public final Integer h = (Integer) values.get(HEIGHT);

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/BaseCreative.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/BaseCreative.java
@@ -2,7 +2,7 @@ package com.adsbynimbus.openrtb.impression;
 
 interface BaseCreative {
 
-    String BID_FLOOR = "bidfloor"; //float (default 2.00)
+    String BID_FLOOR = "bidfloor"; //float
     String POSITION = "pos"; // int
     String MIME_TYPES = "mimes"; // String[]
     String SUPPORTED_APIS = "api"; // int[]

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/BaseCreative.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/BaseCreative.java
@@ -1,0 +1,9 @@
+package com.adsbynimbus.openrtb.impression;
+
+interface BaseCreative {
+
+    String BID_FLOOR = "bidfloor"; //float (default 2.00)
+    String POSITION = "pos"; // int
+    String MIME_TYPES = "mimes"; // String[]
+    String SUPPORTED_APIS = "api"; // int[]
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Format.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Format.java
@@ -1,0 +1,25 @@
+package com.adsbynimbus.openrtb.impression;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface Format {
+
+    //Share format parameter
+    String FORMAT = "format";
+
+    String WIDTH = "w";
+    String HEIGHT = "h";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Format build() {
+            final Map values = getValues();
+            return new Format() {
+                public final int w = (int) values.get(WIDTH);
+                public final int h = (int) values.get(HEIGHT);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Impression.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Impression.java
@@ -1,0 +1,33 @@
+package com.adsbynimbus.openrtb.impression;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+import static com.adsbynimbus.openrtb.impression.BaseCreative.BID_FLOOR;
+
+public interface Impression {
+
+    String BANNER = "banner"; // Banner
+    String VIDEO = "video"; // Video
+    String DISPLAY_MANAGER = "displaymanager";
+    String DISPLAY_MANAGER_SERVER = "displaymanagerserver";
+    String INTERSTITIAL = "instl"; //int (default 0; 0 = not interstitial, 1 = interstitial or full screen)
+    String REQUIRE_HTTPS = "secure"; //int (default: 1, 0 = not secure, 1 = require https)
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Impression build() {
+            final Map values = getValues();
+            return new Impression() {
+                public final Banner banner = (Banner) values.get(BANNER);
+                public final Video video = (Video) values.get(VIDEO);
+                public final String displaymanager = (String) values.get(DISPLAY_MANAGER);
+                public final String displaymanagerserver = (String) values.get(DISPLAY_MANAGER_SERVER);
+                public final int instl = (int) (values.containsKey(INTERSTITIAL) ? values.get(INTERSTITIAL) : 0);
+                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 1f);
+                public final int secure = (int) (values.containsKey(REQUIRE_HTTPS) ? values.get(REQUIRE_HTTPS) : 1);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Impression.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Impression.java
@@ -24,9 +24,9 @@ public interface Impression {
                 public final Video video = (Video) values.get(VIDEO);
                 public final String displaymanager = (String) values.get(DISPLAY_MANAGER);
                 public final String displaymanagerserver = (String) values.get(DISPLAY_MANAGER_SERVER);
-                public final int instl = (int) (values.containsKey(INTERSTITIAL) ? values.get(INTERSTITIAL) : 0);
-                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 1f);
-                public final int secure = (int) (values.containsKey(REQUIRE_HTTPS) ? values.get(REQUIRE_HTTPS) : 1);
+                public final Integer instl = (Integer) values.get(INTERSTITIAL); // Server default 0
+                public final Float bidfloor = (Float) values.get(BID_FLOOR); // Server default 1.0
+                public final Integer secure = (Integer) values.get(REQUIRE_HTTPS); // Server default 1
             };
         }
     }

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Video.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Video.java
@@ -24,20 +24,20 @@ public interface Video extends BaseCreative {
         default Video build() {
             final Map values = getValues();
             return new Video() {
-                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 3f);
+                public final Float bidfloor = (Float) values.get(BID_FLOOR); // Server default 3
                 public final String[] mimes = (String[]) values.get(MIME_TYPES);
-                public final int minduration = (int) (values.containsKey(MIN_DURATION) ? values.get(MIN_DURATION) : 0);
-                public final int maxduration = (int) (values.containsKey(MAX_DURATION) ? values.get(MAX_DURATION) : 60);
+                public final Integer minduration = (int) values.get(MIN_DURATION); // Server default 0
+                public final Integer maxduration = (int) values.get(MAX_DURATION); // Server default 60
                 public final int[] protocols = (int[]) values.get(PROTOCOLS);
                 public final int w = (int) values.get(WIDTH);
                 public final int h = (int) values.get(HEIGHT);
-                public final int startdelay = (int) (values.containsKey(START_DELAY) ? values.get(START_DELAY) : 0);
-                public final Integer skip = (Integer) values.get(SKIP);
-                public final int skipmin = (int) (values.containsKey(SKIP_MIN) ? values.get(SKIP_MIN) : 0);
-                public final int skipafter = (int) (values.containsKey(SKIP_AFTER) ? values.get(SKIP_AFTER) : 0);
-                public final int minbitrate = (int) (values.containsKey(MIN_BITRATE) ? values.get(MIN_BITRATE) : 0);
-                public final int maxbitrate = (int) (values.containsKey(MAX_BITRATE) ? values.get(MAX_BITRATE) : 0);
-                public final Integer pos = (Integer) values.get(POSITION);
+                public final Integer startdelay = (Integer) values.get(START_DELAY); // Server default 0;
+                public final Integer skip = (Integer) values.get(SKIP); // optional
+                public final Integer skipmin = (Integer) values.get(SKIP_MIN); // Server default 0
+                public final Integer skipafter = (Integer) values.get(SKIP_AFTER); // Server default 0
+                public final Integer minbitrate = (Integer) values.get(MIN_BITRATE); // Server default 0
+                public final Integer maxbitrate = (Integer) values.get(MAX_BITRATE); // Server default 0
+                public final Integer pos = (Integer) values.get(POSITION); // Optional
                 public final int[] api = (int[]) values.get(SUPPORTED_APIS);
             };
         }

--- a/java/src/main/java/com/adsbynimbus/openrtb/impression/Video.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/impression/Video.java
@@ -1,0 +1,45 @@
+package com.adsbynimbus.openrtb.impression;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+import static com.adsbynimbus.openrtb.impression.Format.HEIGHT;
+import static com.adsbynimbus.openrtb.impression.Format.WIDTH;
+
+public interface Video extends BaseCreative {
+
+    String MIN_DURATION = "minduration"; // int default 0
+    String MAX_DURATION = "maxduration"; // int default 60
+    String PROTOCOLS = "protocols"; // int[]
+    String START_DELAY = "startdelay"; // int default 0
+    String SKIP = "skip"; // int (0 = no, 1 = can skip)
+    String SKIP_MIN = "skipmin"; //int default 0;
+    String SKIP_AFTER = "skipafter"; //int default 0;
+    String MIN_BITRATE = "minbitrate"; // int default 0;
+    String MAX_BITRATE = "maxbitrate"; // int default 20000
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Video build() {
+            final Map values = getValues();
+            return new Video() {
+                public final float bidfloor = (float) (values.containsKey(BID_FLOOR) ? values.get(BID_FLOOR) : 3f);
+                public final String[] mimes = (String[]) values.get(MIME_TYPES);
+                public final int minduration = (int) (values.containsKey(MIN_DURATION) ? values.get(MIN_DURATION) : 0);
+                public final int maxduration = (int) (values.containsKey(MAX_DURATION) ? values.get(MAX_DURATION) : 60);
+                public final int[] protocols = (int[]) values.get(PROTOCOLS);
+                public final int w = (int) values.get(WIDTH);
+                public final int h = (int) values.get(HEIGHT);
+                public final int startdelay = (int) (values.containsKey(START_DELAY) ? values.get(START_DELAY) : 0);
+                public final Integer skip = (Integer) values.get(SKIP);
+                public final int skipmin = (int) (values.containsKey(SKIP_MIN) ? values.get(SKIP_MIN) : 0);
+                public final int skipafter = (int) (values.containsKey(SKIP_AFTER) ? values.get(SKIP_AFTER) : 0);
+                public final int minbitrate = (int) (values.containsKey(MIN_BITRATE) ? values.get(MIN_BITRATE) : 0);
+                public final int maxbitrate = (int) (values.containsKey(MAX_BITRATE) ? values.get(MAX_BITRATE) : 0);
+                public final Integer pos = (Integer) values.get(POSITION);
+                public final int[] api = (int[]) values.get(SUPPORTED_APIS);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/internal/NimbusRTB.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/internal/NimbusRTB.java
@@ -1,0 +1,10 @@
+package com.adsbynimbus.openrtb.internal;
+
+import java.util.Map;
+
+public interface NimbusRTB {
+
+    interface Builder {
+        Map getValues();
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/publisher/App.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/publisher/App.java
@@ -1,0 +1,31 @@
+package com.adsbynimbus.openrtb.publisher;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface App extends Publisher {
+
+    String BUNDLE = "bundle";
+    String STORE_URL = "storeurl";
+    String PAID = "paid"; //Integer
+    String PUBLISHER = "publisher";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        Map<String, Object> getValues();
+
+        default App build() {
+            final Map values = getValues();
+            return new App() {
+                public final String name = (String) values.get(NAME);
+                public final String bundle = (String) values.get(BUNDLE);
+                public final String domain = (String) values.get(DOMAIN);
+                public final String storeurl = (String) values.get(STORE_URL);
+                public final String[] cat = (String[]) values.get(CONTENT_CATEGORIES);
+                public final Integer paid = (Integer) values.get(PAID);
+                public final String publisher = (String) values.get(PUBLISHER);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/publisher/BasePublisher.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/publisher/BasePublisher.java
@@ -1,0 +1,8 @@
+package com.adsbynimbus.openrtb.publisher;
+
+interface BasePublisher {
+
+    String NAME = "name";
+    String DOMAIN = "domain";
+    String CONTENT_CATEGORIES = "cat"; // String[]
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/publisher/Publisher.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/publisher/Publisher.java
@@ -1,0 +1,26 @@
+package com.adsbynimbus.openrtb.publisher;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface Publisher extends BasePublisher {
+
+    // Extensions
+    String FACEBOOK_APP_ID = "facebook_app_id";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Publisher build() {
+            final Map values = getValues();
+            return new Publisher() {
+                public final String name = (String) values.get(NAME);
+                public final String domain = (String) values.get(DOMAIN);
+                public final String[] cat = (String[]) values.get(CONTENT_CATEGORIES);
+                public final Object ext = values.containsKey(FACEBOOK_APP_ID) ? new Object() {
+                    public final String facebook_app_id = (String) values.get(FACEBOOK_APP_ID);
+                } : null;
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/user/Device.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/user/Device.java
@@ -1,0 +1,38 @@
+package com.adsbynimbus.openrtb.user;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface Device {
+
+    String USER_AGENT = "ua";
+    String GEO = "geo"; //GEO object
+    String IP_ADDRESS = "ip";
+    String DEVICE_TYPE = "devicetype";
+    String MAKE = "make";
+    String MODEL = "model";
+    String OS = "os";
+    String OS_VERSION = "osv";
+    String CONNECTION_TYPE = "connectiontype"; //Integer
+    String ADVERTISING_ID = "ifa";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Device build() {
+            final Map values = getValues();
+            return new Device() {
+                public final String ua = (String) values.get(USER_AGENT);
+                public final Geo geo = (Geo) values.get(GEO);
+                public final String ip = (String) values.get(IP_ADDRESS);
+                public final Integer devicetype = (Integer) values.get(DEVICE_TYPE);
+                public final String make = (String) values.get(MAKE);
+                public final String model = (String) values.get(MODEL);
+                public final String os = (String) values.get(OS);
+                public final String osv = (String) values.get(OS_VERSION);
+                public final Integer connectiontype = (Integer) values.get(CONNECTION_TYPE);
+                public final String ifa = (String) values.get(ADVERTISING_ID);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/user/Geo.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/user/Geo.java
@@ -1,0 +1,30 @@
+package com.adsbynimbus.openrtb.user;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface Geo {
+
+    String LATITUDE = "lat"; // Float
+    String LONGITUDE = "lon"; // Float (optional)
+    String TYPE = "type"; // Integer
+    String ACCURACY =  "accuracy"; // Integer
+    String COUNTRY = "country";
+    String CITY = "city";
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Geo build() {
+            final Map values = getValues();
+            return new Geo() {
+                public final Float lat = (Float) values.get(LATITUDE);
+                public final Float lon = (Float) values.get(LONGITUDE);
+                public final Integer type = (Integer) values.get(TYPE);
+                public final Integer accuracy = (Integer) values.get(ACCURACY);
+                public final String country = (String) values.get(COUNTRY);
+                public final String city = (String) values.get(CITY);
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/user/Regs.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/user/Regs.java
@@ -1,0 +1,27 @@
+package com.adsbynimbus.openrtb.user;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface Regs {
+
+    String COPPA = "coppa"; // int
+
+    //Extensions
+    String GDPR_CONSENT = "gdpr"; // int
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default Regs build() {
+            final Map values = getValues();
+            return new Regs() {
+
+                public final int coppa = (int) values.get(COPPA);
+                public final Object ext = values.containsKey(GDPR_CONSENT) ? new Object() {
+                    public final int gdpr = (int) values.get(GDPR_CONSENT);
+                } : null;
+            };
+        }
+    }
+}

--- a/java/src/main/java/com/adsbynimbus/openrtb/user/User.java
+++ b/java/src/main/java/com/adsbynimbus/openrtb/user/User.java
@@ -1,0 +1,36 @@
+package com.adsbynimbus.openrtb.user;
+
+import com.adsbynimbus.openrtb.internal.NimbusRTB;
+
+import java.util.Map;
+
+public interface User {
+
+    String AGE = "age"; // Integer
+    String BUYER_ID = "buyerid";
+    String YEAR_OF_BIRTH = "yob"; // Integer
+    String GENDER = "gender";
+
+    // Nimbus Extensions
+    String CONSENT = "consent";
+    String DID_CONSENT = "did_consent"; // int
+
+    interface Builder extends NimbusRTB.Builder {
+
+        default User build() {
+            final Map values = getValues();
+            return new User() {
+                public final Integer age = (Integer) values.get(AGE);
+                public final String buyerid = (String) values.get(BUYER_ID);
+                public final Integer yob = (Integer) values.get(YEAR_OF_BIRTH);
+                public final String gender = (String) values.get(GENDER);
+                public final Object ext =
+                        values.containsKey(CONSENT) || values.containsKey(DID_CONSENT) ? new Object() {
+                            public final String consent = (String) values.get(CONSENT);
+                            public final int did_consent =
+                                    (int) (values.containsKey(DID_CONSENT) ? values.get(DID_CONSENT) : 0);
+                        } : null;
+            };
+        }
+    }
+}


### PR DESCRIPTION
- Added NImbus Request objects and default builder implementations [timehop/tickets#2527]

This is pure java 8 implementation can be used as is to generate and send a request to Nimbus. The design has a lot of benefits in that the implementation can be determined by the user and it will properly default fields to the correct values, null out fields that were not set, and force a crash if the user does not set a required field. The default object generated by the builders should work with any JSON serializer as most include a reflective serializer that will automatically build the correct response. This will be further extended by an android platform implementation in this repo that will add in static code analysis tools to warn the users if they are trying to do something incorrectly and overrides of the Builders can generate implementations that are memory efficient, fast to serialize, and the default implementation will be removed by the code shrinking tool keeping the dex count impact low and the library incredibly small.