### PR TITLE
Client: Grabbing Nimbus specific SDK headers from Request

### DIFF
--- a/go/client/client_test.go
+++ b/go/client/client_test.go
@@ -714,7 +714,7 @@ func TestWithHeaders(t *testing.T) {
 			option := WithHeaders(tt.args.headers)
 			option(req)
 			// https://golang.org/pkg/net/textproto/#MIMEHeader.Get
-			if got := req.Header[tt.args.key]; got[0] != tt.want {
+			if got, ok := req.Header[tt.args.key]; !ok || (got[0] != tt.want) {
 				t.Errorf("WithHeaders() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Making the header passing strict to avoid unintentional headers
affecting content-encoding in the response. If later we want
to add support, we can rename the function to WithNimbusHeaders
and add WithHeaderContentEncoding