### PR TITLE
Renamed 'master' branch to 'main'

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,8 +2,8 @@
 
 ## Adding platforms
 1) Create or checkout a branch named platform/{platform-name}
-2) Commit code and open a Pull Request to master
-3) Squash and merge into master
+2) Commit code and open a Pull Request to main
+3) Squash and merge into main
 4) Delete branch platform/{platform-name}
 
 ## Working on platform updates

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,7 +3,7 @@ name: Android
 on:
   pull_request:
     branches:
-      - master
+      - main
     tags-ignore:
       - '**'
     paths:


### PR DESCRIPTION
@marcsantiago Getting ahead of the curve on Github making this the default behavior. 

After this is merged I am going to update the default branch  in the settings to 'main', update the branch protections, and then delete the master branch as long as there is nothing externally you can think of depending on that branch name being there.

After you've checked out the new 'main' branch, run the following command to reset your HEAD tag to track main instead of master: `git remote set-head origin main`