### PR TITLE
Downgraded Kotlin to 1.5.31 for compatibility with 1.4

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -27,3 +27,4 @@ kotlin.mpp.stability.nowarn=true
 kotlin.native.enableDependencyPropagation=false
 # The following disables warnings for targets not supported by the current dev platform
 kotlin.native.ignoreDisabledTargets=true
+kotlin.stdlib.default.dependency=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android = "7.1.1"
+android = "7.0.3" # Do Not Update this until Kotlin Updated to 1.6.10
 android-buildtools = "32.0.0"
 dokka = "1.6.10"
 kotest = "5.1.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,9 +3,8 @@ android = "7.1.1"
 android-buildtools = "32.0.0"
 dokka = "1.6.10"
 kotest = "5.1.0"
-kotlin = "1.6.10"
-kotlin-api = "1.4"
-serialization = "1.3.2"
+kotlin = "1.5.31"
+serialization = "1.3.1"
 
 [plugins]
 android = { id = "com.android.library", version.ref = "android" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
@@ -1,8 +1,11 @@
 package com.adsbynimbus.openrtb.request
 
+import com.adsbynimbus.openrtb.response.BidResponse
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
 
 /**
  * The top-level bid request object contains a globally unique bid request or auction ID.
@@ -65,5 +68,8 @@ public class BidRequest(
 
         /** The current supported OpenRTB version by this request object */
         public const val OPENRTB_VERSION: String = "2.5"
+
+        @JvmStatic
+        public fun BidRequest.toJson(): String = Json.encodeToString(serializer(), this)
     }
 }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
@@ -2,7 +2,9 @@ package com.adsbynimbus.openrtb.response
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmField
+import kotlin.jvm.JvmStatic
 
 /**
  * A winning bid response from Nimbus
@@ -53,5 +55,9 @@ public class BidResponse(
     public val impression_trackers: Array<String>? by trackers
     /** Urls to fire a request to when a click is registered */
     public val click_trackers: Array<String>? by trackers
-}
 
+    public companion object {
+        @JvmStatic
+        public fun fromJson(json: String): BidResponse = Json.decodeFromString(serializer(), json)
+    }
+}


### PR DESCRIPTION
This PR downgrades Kotlin to 1.5.31 and Serialzation to 1.3.1 for binary compatibility with Kotlin 1.4.

Additionally, the Android Gradle Plugin was downgraded to 7.0.3 to fix an issue with the Gradle Module Metadata that is published from the Kotlin Multiplatform Plugin if used in conjunction with version AGP 7.1 or above as documented here: https://youtrack.jetbrains.com/issue/KT-49798

When support for Kotlin 1.4 is dropped, the Kotlin version can be updated to 1.6 and the Android Gradle Plugin can be updated as well. 

In addition to these changes, helper methods were added for serializing and deserializing the request and respose objects so consumers of this library do not need to add the serialization library separately, it will be included as a runtime dependency of the build.