### PR TITLE
Updated builds to use v3 actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,43 +1,36 @@
 name: Go
 on:
   push:
-    paths:
-      - 'go/**'
-      - '.github/workflows/go*'
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
-
   test:
-    name: Test Go OpenRTB
+    name: Running Go Tests
     runs-on: ubuntu-latest
     steps:
-    - name: Set up Go 1.12
-      uses: actions/setup-go@v3
-      with:
-        go-version: '1.12'
-      id: go
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.13
+        id: go
 
-    - name: Get dependencies
-      env:
-        GOPATH: /home/runner/work/nimbus-openrtb/go
-      run: |
-        go get -v -t -d ./...
-        if [ -f Gopkg.toml ]; then
-            curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
-            dep ensure
-        fi
-        if [ ! -f "/tmp/GeoLite2-City.mmdb.gz" ]; then
-            wget -O /tmp/GeoLite2-City.mmdb.gz https://s3.amazonaws.com/timehop.uploads/oneoffs/GeoLite2-City.mmdb.gz
-        fi
-        
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        path: go/src/github.com/timehop/nimbus-openrtb
-        
-    - name: Run Test
-      env:
-        LOAD_MAXMIND_FROM_FILE: "true"
-        MAXMIND_FILE: "/tmp/GeoLite2-City.mmdb.gz"
-        GOPATH: /home/runner/work/nimbus-openrtb/go
-      run: go test ./... -race -cover -v -short
+      - name: Debug
+        run: |
+            pwd
+            echo ${GOPATH}
+            echo ${GOROOT}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+          path: home/runner/work/nimbus-openrtb/nimbus-openrtb
+
+      - name: Run Test
+        run: go test ./... -race -cover -v -short
+        env:
+          GOPATH: /home/runner/work/nimbus-openrtb/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.13
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: 1.13
         id: go
@@ -25,12 +25,10 @@ jobs:
             echo ${GOROOT}
 
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
-          path: home/runner/work/nimbus-openrtb/nimbus-openrtb
+        uses: actions/checkout@v3
 
       - name: Run Test
         run: go test ./... -race -cover -v -short
+        working-directory: ./go
         env:
           GOPATH: /home/runner/work/nimbus-openrtb/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,15 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go 1.12
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: 1.12
       id: go
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v1
+      uses: actions/checkout@v3
       with:
-        fetch-depth: 1
         path: go/src/github.com/timehop/nimbus-openrtb
 
     - name: Get dependencies

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,13 +14,8 @@ jobs:
     - name: Set up Go 1.12
       uses: actions/setup-go@v3
       with:
-        go-version: 1.12
+        go-version: '1.12'
       id: go
-
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v3
-      with:
-        path: go/src/github.com/timehop/nimbus-openrtb
 
     - name: Get dependencies
       env:
@@ -34,6 +29,12 @@ jobs:
         if [ ! -f "/tmp/GeoLite2-City.mmdb.gz" ]; then
             wget -O /tmp/GeoLite2-City.mmdb.gz https://s3.amazonaws.com/timehop.uploads/oneoffs/GeoLite2-City.mmdb.gz
         fi
+        
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        path: go/src/github.com/timehop/nimbus-openrtb
+        
     - name: Run Test
       env:
         LOAD_MAXMIND_FROM_FILE: "true"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -22,12 +22,6 @@ jobs:
           go-version: 1.13
         id: go
 
-      - name: Debug
-        run: |
-            pwd
-            echo ${GOPATH}
-            echo ${GOROOT}
-
       - name: Check out code into the Go module directory
         uses: actions/checkout@v3
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'go/**'
+      - '.github/workflows/go*'
+
 
 jobs:
   test:

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -12,7 +12,6 @@ on:
     tags-ignore:
       - '**'
 
-
   release:
     types: [published]
 
@@ -22,29 +21,28 @@ jobs:
     name: Build, test, and optionally publish Android OpenRTB
     runs-on: macos-latest
     env:
-      TAG_NAME: ${{ github.ref }}
       ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.AWS_ACCESS_KEY }}
       ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.AWS_SECRET_KEY }}
       ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
       ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Java
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
 
       - name: Cache Kotlin packages
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
           restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
             ${{ runner.os }}-konan-
 
       - name: Fix NDK Bug
@@ -56,3 +54,6 @@ jobs:
       - name: Publish
         if: success() && github.event_name == 'release'
         run: ./gradlew publish
+
+      - name: Stop Gradle Daemon for Caching
+        run: ./gradlew --stop

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -1,59 +1,59 @@
-name: Kotlin
-
-on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - 'kotlin/**'
-      - '.github/workflows/kotlin*'
-
-  push:
-    tags-ignore:
-      - '**'
-
-  release:
-    types: [published]
-
-jobs:
-
-  build:
-    name: Build, test, and optionally publish Android OpenRTB
-    runs-on: macos-latest
-    env:
-      ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.AWS_ACCESS_KEY }}
-      ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.AWS_SECRET_KEY }}
-      ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
-      ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
-          cache: 'gradle'
-
-      - name: Cache Kotlin packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-            ${{ runner.os }}-konan-
-
-      - name: Fix NDK Bug
-        run: echo "ndk.dir=$ANDROID_HOME/ndk-bundle" > local.properties
-
-      - name: Build
-        run: ./gradlew test
-
-      - name: Publish
-        if: success() && github.event_name == 'release'
-        run: ./gradlew publish
-
-      - name: Stop Gradle Daemon for Caching
-        run: ./gradlew --stop
+#name: Kotlin
+#
+#on:
+#  pull_request:
+#    branches:
+#      - main
+#    paths:
+#      - 'kotlin/**'
+#      - '.github/workflows/kotlin*'
+#
+#  push:
+#    tags-ignore:
+#      - '**'
+#
+#  release:
+#    types: [published]
+#
+#jobs:
+#
+#  build:
+#    name: Build, test, and optionally publish Android OpenRTB
+#    runs-on: macos-latest
+#    env:
+#      ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.AWS_ACCESS_KEY }}
+#      ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.AWS_SECRET_KEY }}
+#      ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
+#      ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
+#    steps:
+#      - name: Checkout code
+#        uses: actions/checkout@v3
+#
+#      - name: Setup Java
+#        uses: actions/setup-java@v3
+#        with:
+#          distribution: 'temurin'
+#          java-version: 11
+#          cache: 'gradle'
+#
+#      - name: Cache Kotlin packages
+#        uses: actions/cache@v3
+#        with:
+#          path: ~/.konan
+#          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
+#          restore-keys: |
+#            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
+#            ${{ runner.os }}-konan-
+#
+#      - name: Fix NDK Bug
+#        run: echo "ndk.dir=$ANDROID_HOME/ndk-bundle" > local.properties
+#
+#      - name: Build
+#        run: ./gradlew test
+#
+#      - name: Publish
+#        if: success() && github.event_name == 'release'
+#        run: ./gradlew publish
+#
+#      - name: Stop Gradle Daemon for Caching
+#        run: ./gradlew --stop

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -1,59 +1,59 @@
-#name: Kotlin
-#
-#on:
-#  pull_request:
-#    branches:
-#      - main
-#    paths:
-#      - 'kotlin/**'
-#      - '.github/workflows/kotlin*'
-#
-#  push:
-#    tags-ignore:
-#      - '**'
-#
-#  release:
-#    types: [published]
-#
-#jobs:
-#
-#  build:
-#    name: Build, test, and optionally publish Android OpenRTB
-#    runs-on: macos-latest
-#    env:
-#      ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.AWS_ACCESS_KEY }}
-#      ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.AWS_SECRET_KEY }}
-#      ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
-#      ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
-#    steps:
-#      - name: Checkout code
-#        uses: actions/checkout@v3
-#
-#      - name: Setup Java
-#        uses: actions/setup-java@v3
-#        with:
-#          distribution: 'temurin'
-#          java-version: 11
-#          cache: 'gradle'
-#
-#      - name: Cache Kotlin packages
-#        uses: actions/cache@v3
-#        with:
-#          path: ~/.konan
-#          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-#          restore-keys: |
-#            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-#            ${{ runner.os }}-konan-
-#
-#      - name: Fix NDK Bug
-#        run: echo "ndk.dir=$ANDROID_HOME/ndk-bundle" > local.properties
-#
-#      - name: Build
-#        run: ./gradlew test
-#
-#      - name: Publish
-#        if: success() && github.event_name == 'release'
-#        run: ./gradlew publish
-#
-#      - name: Stop Gradle Daemon for Caching
-#        run: ./gradlew --stop
+name: Kotlin
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'kotlin/**'
+      - '.github/workflows/kotlin*'
+
+  push:
+    tags-ignore:
+      - '**'
+
+  release:
+    types: [published]
+
+jobs:
+
+  build:
+    name: Build, test, and optionally publish Android OpenRTB
+    runs-on: macos-latest
+    env:
+      ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.AWS_ACCESS_KEY }}
+      ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.AWS_SECRET_KEY }}
+      ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
+      ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+          cache: 'gradle'
+
+      - name: Cache Kotlin packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
+            ${{ runner.os }}-konan-
+
+      - name: Fix NDK Bug
+        run: echo "ndk.dir=$ANDROID_HOME/ndk-bundle" > local.properties
+
+      - name: Build
+        run: ./gradlew test
+
+      - name: Publish
+        if: success() && github.event_name == 'release'
+        run: ./gradlew publish
+
+      - name: Stop Gradle Daemon for Caching
+        run: ./gradlew --stop

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,14 @@
 # Project-wide Gradle settings.
-
 org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dkotlin.daemon.jvm.options="-Xmx2g -XX:+UseParallelGC"
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
+
+# The following enables the configuration cache which significantly speeds up builds.
+# This is disabled until Kotlin can be updated to a newer version
+#org.gradle.unsafe.configuration-cache=true
+#org.gradle.unsafe.configuration-cache-problems=warn
+#org.gradle.unsafe.configuration-cache.max-problems=5
 
 ## Android Build Settings
 
@@ -11,7 +16,7 @@ android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.buildconfig=false
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
-android.defaults.buildfeatures.shaders=true
+android.defaults.buildfeatures.shaders=false
 android.useAndroidX=true
 
 ### The following opts-in to future publishing behavior of Android Gradle Plugin 8.0

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,17 +2,13 @@
 android = "7.0.3" # Do Not Update this until Kotlin Updated to 1.6.10
 android-buildtools = "32.0.0"
 dokka = "1.6.10"
-kotest = "5.1.0"
-kotlin = "1.5.31"
+kotest = "5.2.1"
 serialization = "1.3.1"
 
 [plugins]
 android = { id = "com.android.library", version.ref = "android" }
-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
 kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }
-kotlin = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 
 [libraries]
 kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -3,16 +3,16 @@ import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.android)
-    alias(libs.plugins.kotlin)
+    kotlin("multiplatform")
     alias(libs.plugins.kotest)
-    alias(libs.plugins.cocoapods)
+    kotlin("native.cocoapods")
     alias(libs.plugins.dokka)
-    alias(libs.plugins.serialization)
+    kotlin("plugin.serialization")
     `maven-publish`
 }
 
 group = "com.adsbynimbus.openrtb"
-version = (System.getenv("TAG_NAME") ?: "0.0.1").split("/").last().let {
+version = (System.getenv("GITHUB_REF") ?: "0.0.1").split("/").last().let {
     if (it.startsWith("v")) it.substring(1) else it
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,12 +1,16 @@
 @file:Suppress("UnstableApiUsage")
 
-enableFeaturePreview("VERSION_CATALOGS")
-
 pluginManagement {
     repositories {
         google()
         mavenCentral()
         gradlePluginPortal()
+    }
+    plugins {
+        val kotlin = "1.5.31"
+        kotlin("multiplatform") version(kotlin)
+        kotlin("native.cocoapods") version(kotlin)
+        kotlin("plugin.serialization") version(kotlin)
     }
 }
 


### PR DESCRIPTION
This PR updates the actions versions to use v3 of the available actions. Addtionally Gradle was updated to 7.4.2 and the build was modified to provide better cache support for changing Kotlin versions.