### PR TITLE
Converting To Classes and Removing Method Properties 

### DIFF
--- a/csharp/OpenRTB.Tests/Tests.cs
+++ b/csharp/OpenRTB.Tests/Tests.cs
@@ -1,391 +1,394 @@
 ﻿using System.Diagnostics;
-using OpenRTB.Enumerations;
-using OpenRTB.Request;
-using NUnit.Framework;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
+using NUnit.Framework;
+using OpenRTB.Enumerations;
+using OpenRTB.Request;
 
 namespace OpenRTB.Tests {
-	[SetUpFixture]
-	public class SetupTrace {
-		[OneTimeSetUp]
-		public void StartTest() {
-			Trace.Listeners.Add(new ConsoleTraceListener());
-		}
+    [SetUpFixture]
+    public class SetupTrace {
+        [OneTimeSetUp]
+        public void StartTest() {
+            Trace.Listeners.Add(new ConsoleTraceListener());
+        }
 
-		[OneTimeTearDown]
-		public void EndTest() {
-			Trace.Flush();
-		}
-	}
+        [OneTimeTearDown]
+        public void EndTest() {
+            Trace.Flush();
+        }
+    }
 
-	[TestFixture]
-	public class Tests {
-		[Test]
-		public void TestValidateBidRequest() {
-			var tests = new[] {
-				new ValidateBidRequestTableData(name: "request should be valid", new BidRequest {
-					App = new App {
-						Name = "foo",
-						Bundle = "com.foo",
-						Domain = "foo.com",
-						StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
-						Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-						Publisher = new Publisher {
-							Name = "foo",
-							Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-							Domain = "foo.com",
-						}
-					},
-					Device = new Device {
-						DeviceType = DeviceType.Phone,
-						Ua =
-							"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
-						Ip = "71.125.59.151",
-						Make = "Pixel 2 XL",
-						Model = "Samsung",
-						Os = "android",
-						Osv = "4.2.4",
-						Language = "en",
-						ConnectionType = ConnectionType.Wifi,
-						Ifa = "13579176-e94e-4e6e-96ae-572b787af21c",
-					},
-					Format = new Format {
-						H = 1920,
-						W = 1080,
-					},
-					User = new User {
-						Age = 30,
-						Yob = 1991,
-						Gender = "male",
-					},
-					Ext = new BidRequestExt {
-						ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
-						SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4",
-					},
-					Imp = new[] {
-						new Imp {
-							Banner = new Banner {
-								BidFloor = 2.00f,
-								H = 480,
-								W = 320,
-								Pos = Position.Fullscreen,
-								Format = new[] {
-									new Format {
-										H = 1920,
-										W = 1080,
-									},
-									new Format {
-										H = 600,
-										W = 300,
-									},
-								},
-								BAttr = new[]
-									{ CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
-							},
-							Video = new Video {
-								BidFloor = 3.00f,
-								Mimes = new[] { "foo", "bar" },
-								MinBitrate = 1,
-								MaxBitrate = 200000,
-								Pos = Position.Fullscreen,
-								MinDuration = 15,
-								MaxDuration = 60,
-								H = 1080,
-								W = 1920,
-							},
-							Instl = 1,
-							Secure = 1,
-							Ext = new ImpExt {
-								Position = "App Open"
-							}
-						},
-					},
-				}, false),
-				new ValidateBidRequestTableData(name: "request should be invalid the banner h and w are missing",
-					new BidRequest {
-						App = new App {
-							Name = "foo",
-							Bundle = "com.foo",
-							Domain = "foo.com",
-							StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
-							Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-							Publisher = new Publisher {
-								Name = "foo",
-								Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-								Domain = "foo.com",
-							}
-						},
-						Device = new Device {
-							DeviceType = DeviceType.Phone,
-							Ua =
-								"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
-							Ip = "71.125.59.151",
-							Make = "Pixel 2 XL",
-							Model = "Samsung",
-							Os = "android",
-							Osv = "4.2.4",
-							Language = "en",
-							ConnectionType = ConnectionType.Wifi,
-							Ifa = "13579176-e94e-4e6e-96ae-572b787af21c",
-						},
-						Format = new Format {
-							H = 1920,
-							W = 1080,
-						},
-						User = new User {
-							Age = 30,
-							Yob = 1991,
-							Gender = "male",
-						},
-						Ext = new BidRequestExt {
-							ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
-							SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4",
-						},
-						Imp = new[] {
-							new Imp {
-								Banner = new Banner {
-									BidFloor = 2.00f,
-									Pos = Position.Fullscreen,
-									Format = new[] {
-										new Format {
-											H = 1920,
-											W = 1080,
-										},
-										new Format {
-											H = 600,
-											W = 300,
-										},
-									},
-									BAttr = new[]
-										{ CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
-								},
-								Video = new Video {
-									BidFloor = 3.00f,
-									H = 300,
-									W = 600,
-									Mimes = new[] { "foo", "bar" },
-									MinBitrate = 1,
-									MaxBitrate = 200000,
-									Pos = Position.Fullscreen,
-									MinDuration = 15,
-									MaxDuration = 60,
-								},
-								Instl = 1,
-								Secure = 1,
-								Ext = new ImpExt {
-									Position = "App Open"
-								}
-							},
-						},
-					}, true),
-			};
+    [TestFixture]
+    public class Tests {
+        [Test]
+        public void TestValidateBidRequest() {
+            var tests = new[] {
+                new ValidateBidRequestTableData("request should be valid", new BidRequest {
+                    App = new App {
+                        Name = "foo",
+                        Bundle = "com.foo",
+                        Domain = "foo.com",
+                        StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
+                        Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                        Publisher = new Publisher {
+                            Name = "foo",
+                            Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                            Domain = "foo.com"
+                        }
+                    },
+                    Device = new Device {
+                        DeviceType = DeviceType.Phone,
+                        Ua =
+                            "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
+                        Ip = "71.125.59.151",
+                        Make = "Pixel 2 XL",
+                        Model = "Samsung",
+                        Os = "android",
+                        Osv = "4.2.4",
+                        Language = "en",
+                        ConnectionType = ConnectionType.Wifi,
+                        Ifa = "13579176-e94e-4e6e-96ae-572b787af21c"
+                    },
+                    Format = new Format {
+                        H = 1920,
+                        W = 1080
+                    },
+                    User = new User {
+                        Age = 30,
+                        Yob = 1991,
+                        Gender = "male"
+                    },
+                    Ext = new BidRequestExt {
+                        ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
+                        SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4"
+                    },
+                    Imp = new[] {
+                        new Imp {
+                            Banner = new Banner {
+                                BidFloor = 2.00f,
+                                H = 480,
+                                W = 320,
+                                Pos = Position.Fullscreen,
+                                Format = new[] {
+                                    new Format {
+                                        H = 1920,
+                                        W = 1080
+                                    },
+                                    new Format {
+                                        H = 600,
+                                        W = 300
+                                    }
+                                },
+                                BAttr = new[]
+                                    { CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
+                            },
+                            Video = new Video {
+                                BidFloor = 3.00f,
+                                Mimes = new[] { "foo", "bar" },
+                                MinBitrate = 1,
+                                MaxBitrate = 200000,
+                                Pos = Position.Fullscreen,
+                                MinDuration = 15,
+                                MaxDuration = 60,
+                                H = 1080,
+                                W = 1920
+                            },
+                            Instl = 1,
+                            Secure = 1,
+                            Ext = new ImpExt {
+                                Position = "App Open"
+                            }
+                        }
+                    }
+                }, false),
+                new ValidateBidRequestTableData("request should be invalid the banner h and w are missing",
+                    new BidRequest {
+                        App = new App {
+                            Name = "foo",
+                            Bundle = "com.foo",
+                            Domain = "foo.com",
+                            StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
+                            Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                            Publisher = new Publisher {
+                                Name = "foo",
+                                Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                                Domain = "foo.com"
+                            }
+                        },
+                        Device = new Device {
+                            DeviceType = DeviceType.Phone,
+                            Ua =
+                                "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
+                            Ip = "71.125.59.151",
+                            Make = "Pixel 2 XL",
+                            Model = "Samsung",
+                            Os = "android",
+                            Osv = "4.2.4",
+                            Language = "en",
+                            ConnectionType = ConnectionType.Wifi,
+                            Ifa = "13579176-e94e-4e6e-96ae-572b787af21c"
+                        },
+                        Format = new Format {
+                            H = 1920,
+                            W = 1080
+                        },
+                        User = new User {
+                            Age = 30,
+                            Yob = 1991,
+                            Gender = "male"
+                        },
+                        Ext = new BidRequestExt {
+                            ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
+                            SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4"
+                        },
+                        Imp = new[] {
+                            new Imp {
+                                Banner = new Banner {
+                                    BidFloor = 2.00f,
+                                    Pos = Position.Fullscreen,
+                                    Format = new[] {
+                                        new Format {
+                                            H = 1920,
+                                            W = 1080
+                                        },
+                                        new Format {
+                                            H = 600,
+                                            W = 300
+                                        }
+                                    },
+                                    BAttr = new[]
+                                        { CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
+                                },
+                                Video = new Video {
+                                    BidFloor = 3.00f,
+                                    H = 300,
+                                    W = 600,
+                                    Mimes = new[] { "foo", "bar" },
+                                    MinBitrate = 1,
+                                    MaxBitrate = 200000,
+                                    Pos = Position.Fullscreen,
+                                    MinDuration = 15,
+                                    MaxDuration = 60
+                                },
+                                Instl = 1,
+                                Secure = 1,
+                                Ext = new ImpExt {
+                                    Position = "App Open"
+                                }
+                            }
+                        }
+                    }, true)
+            };
 
-			foreach (var tt in tests) {
-				Debug.WriteLine($"Running Test {tt.Name}");
-				if (tt.WantError) {
-					void TestSerialize() => JsonConvert.SerializeObject(tt.Request);
-					Assert.Throws<JsonSerializationException>(TestSerialize);
-					return;
-				}
+            foreach (var tt in tests) {
+                Debug.WriteLine($"Running Test {tt.Name}");
+                if (tt.WantError) {
+                    void TestSerialize() {
+                        JsonConvert.SerializeObject(tt.Request);
+                    }
 
-				// this method should be called with 0 exceptions thrown
-				_ = JsonConvert.SerializeObject(tt.Request);
-			}
-		}
+                    Assert.Throws<JsonSerializationException>(TestSerialize);
+                    return;
+                }
 
-		[Test]
-		public void TestBidRequestSerialization() {
-			const string expected =
-				"{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";
+                // this method should be called with 0 exceptions thrown
+                _ = JsonConvert.SerializeObject(tt.Request);
+            }
+        }
 
-			var bidRequest = new BidRequest {
-				App = new App {
-					Name = "foo",
-					Bundle = "com.foo",
-					Domain = "foo.com",
-					StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
-					Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-					Publisher = new Publisher {
-						Name = "foo",
-						Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-						Domain = "foo.com",
-					}
-				},
-				Device = new Device {
-					DeviceType = DeviceType.Phone,
-					Ua =
-						"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
-					Ip = "71.125.59.151",
-					Make = "Pixel 2 XL",
-					Model = "Samsung",
-					Os = "android",
-					Osv = "4.2.4",
-					Language = "en",
-					ConnectionType = ConnectionType.Wifi,
-					Ifa = "13579176-e94e-4e6e-96ae-572b787af21c",
-				},
-				Format = new Format {
-					H = 1920,
-					W = 1080,
-				},
-				User = new User {
-					Age = 30,
-					Yob = 1991,
-					Gender = "male",
-				},
-				Ext = new BidRequestExt {
-					ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
-					SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4",
-				},
-				Imp = new[] {
-					new Imp {
-						Banner = new Banner {
-							BidFloor = 2.00f,
-							H = 480,
-							W = 320,
-							Pos = Position.Fullscreen,
-							Format = new[] {
-								new Format {
-									H = 1920,
-									W = 1080,
-								},
-								new Format {
-									H = 600,
-									W = 300,
-								},
-							},
-							BAttr = new[]
-								{ CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
-						},
-						Video = new Video {
-							BidFloor = 3.00f,
-							Mimes = new[] { "foo", "bar" },
-							MinBitrate = 1,
-							MaxBitrate = 200000,
-							Pos = Position.Fullscreen,
-							MinDuration = 15,
-							MaxDuration = 60,
-							H = 1080,
-							W = 1920,
-						},
-						Instl = 1,
-						Secure = 1,
-						Ext = new ImpExt {
-							Position = "App Open"
-						}
-					},
-				},
-			};
+        [Test]
+        public void TestBidRequestSerialization() {
+            const string expected =
+                "{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";
 
-			var jsonString = JsonConvert.SerializeObject(bidRequest);
-			var json1 = JObject.Parse(jsonString);
-			var json2 = JObject.Parse(expected);
-			Assert.IsTrue(JToken.DeepEquals(json1, json2));
-		}
+            var bidRequest = new BidRequest {
+                App = new App {
+                    Name = "foo",
+                    Bundle = "com.foo",
+                    Domain = "foo.com",
+                    StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
+                    Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                    Publisher = new Publisher {
+                        Name = "foo",
+                        Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                        Domain = "foo.com"
+                    }
+                },
+                Device = new Device {
+                    DeviceType = DeviceType.Phone,
+                    Ua =
+                        "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
+                    Ip = "71.125.59.151",
+                    Make = "Pixel 2 XL",
+                    Model = "Samsung",
+                    Os = "android",
+                    Osv = "4.2.4",
+                    Language = "en",
+                    ConnectionType = ConnectionType.Wifi,
+                    Ifa = "13579176-e94e-4e6e-96ae-572b787af21c"
+                },
+                Format = new Format {
+                    H = 1920,
+                    W = 1080
+                },
+                User = new User {
+                    Age = 30,
+                    Yob = 1991,
+                    Gender = "male"
+                },
+                Ext = new BidRequestExt {
+                    ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
+                    SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4"
+                },
+                Imp = new[] {
+                    new Imp {
+                        Banner = new Banner {
+                            BidFloor = 2.00f,
+                            H = 480,
+                            W = 320,
+                            Pos = Position.Fullscreen,
+                            Format = new[] {
+                                new Format {
+                                    H = 1920,
+                                    W = 1080
+                                },
+                                new Format {
+                                    H = 600,
+                                    W = 300
+                                }
+                            },
+                            BAttr = new[]
+                                { CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
+                        },
+                        Video = new Video {
+                            BidFloor = 3.00f,
+                            Mimes = new[] { "foo", "bar" },
+                            MinBitrate = 1,
+                            MaxBitrate = 200000,
+                            Pos = Position.Fullscreen,
+                            MinDuration = 15,
+                            MaxDuration = 60,
+                            H = 1080,
+                            W = 1920
+                        },
+                        Instl = 1,
+                        Secure = 1,
+                        Ext = new ImpExt {
+                            Position = "App Open"
+                        }
+                    }
+                }
+            };
 
-		[Test]
-		public void TestBidRequestDeserialization() {
-			const string expected =
-				"{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";
+            var jsonString = JsonConvert.SerializeObject(bidRequest);
+            var json1 = JObject.Parse(jsonString);
+            var json2 = JObject.Parse(expected);
+            Assert.IsTrue(JToken.DeepEquals(json1, json2));
+        }
 
-			var bidRequestWant = new BidRequest {
-				App = new App {
-					Name = "foo",
-					Bundle = "com.foo",
-					Domain = "foo.com",
-					StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
-					Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-					Publisher = new Publisher {
-						Name = "foo",
-						Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
-						Domain = "foo.com",
-					}
-				},
-				Device = new Device {
-					DeviceType = DeviceType.Phone,
-					Ua =
-						"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
-					Ip = "71.125.59.151",
-					Make = "Pixel 2 XL",
-					Model = "Samsung",
-					Os = "android",
-					Osv = "4.2.4",
-					Language = "en",
-					ConnectionType = ConnectionType.Wifi,
-					Ifa = "13579176-e94e-4e6e-96ae-572b787af21c",
-				},
-				Format = new Format {
-					H = 1920,
-					W = 1080,
-				},
-				User = new User {
-					Age = 30,
-					Yob = 1991,
-					Gender = "male",
-				},
-				Ext = new BidRequestExt {
-					ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
-					SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4",
-				},
-				Imp = new[] {
-					new Imp {
-						Banner = new Banner {
-							BidFloor = 2.00f,
-							H = 480,
-							W = 320,
-							Pos = Position.Fullscreen,
-							Format = new[] {
-								new Format {
-									H = 1920,
-									W = 1080,
-								},
-								new Format {
-									H = 600,
-									W = 300,
-								},
-							},
-							BAttr = new[]
-								{ CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
-						},
-						Video = new Video {
-							BidFloor = 3.00f,
-							Mimes = new[] { "foo", "bar" },
-							MinBitrate = 1,
-							MaxBitrate = 200000,
-							Pos = Position.Fullscreen,
-							MinDuration = 15,
-							MaxDuration = 60,
-							H = 1080,
-							W = 1920,
-						},
-						Instl = 1,
-						Secure = 1,
-						Ext = new ImpExt {
-							Position = "App Open"
-						}
-					},
-				},
-			};
+        [Test]
+        public void TestBidRequestDeserialization() {
+            const string expected =
+                "{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";
 
-			var bidRequestGot = JsonConvert.DeserializeObject<BidRequest>(expected);
-			var jsonStringGot = JsonConvert.SerializeObject(bidRequestGot);
-			var jsonStringWant = JsonConvert.SerializeObject(bidRequestWant);
-			var json1 = JObject.Parse(jsonStringGot);
-			var json2 = JObject.Parse(jsonStringWant);
-			Assert.IsTrue(JToken.DeepEquals(json1, json2));
-		}
-	}
+            var bidRequestWant = new BidRequest {
+                App = new App {
+                    Name = "foo",
+                    Bundle = "com.foo",
+                    Domain = "foo.com",
+                    StoreUrl = "https://play.google.com/store/apps/details?id=com.foo",
+                    Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                    Publisher = new Publisher {
+                        Name = "foo",
+                        Cat = new[] { "IAB14", "IAB1", "IAB9", "IAB12", "IAB16", "IAB17", "IAB18", "IAB20" },
+                        Domain = "foo.com"
+                    }
+                },
+                Device = new Device {
+                    DeviceType = DeviceType.Phone,
+                    Ua =
+                        "Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36",
+                    Ip = "71.125.59.151",
+                    Make = "Pixel 2 XL",
+                    Model = "Samsung",
+                    Os = "android",
+                    Osv = "4.2.4",
+                    Language = "en",
+                    ConnectionType = ConnectionType.Wifi,
+                    Ifa = "13579176-e94e-4e6e-96ae-572b787af21c"
+                },
+                Format = new Format {
+                    H = 1920,
+                    W = 1080
+                },
+                User = new User {
+                    Age = 30,
+                    Yob = 1991,
+                    Gender = "male"
+                },
+                Ext = new BidRequestExt {
+                    ApiKey = "3b117631-538d-4315-bc47-d4e8ce6527e5",
+                    SessionId = "fab5d528-5ac9-4082-a1ff-968a7f8fefc4"
+                },
+                Imp = new[] {
+                    new Imp {
+                        Banner = new Banner {
+                            BidFloor = 2.00f,
+                            H = 480,
+                            W = 320,
+                            Pos = Position.Fullscreen,
+                            Format = new[] {
+                                new Format {
+                                    H = 1920,
+                                    W = 1080
+                                },
+                                new Format {
+                                    H = 600,
+                                    W = 300
+                                }
+                            },
+                            BAttr = new[]
+                                { CreativeAttributes.AudioAdAutoPlay, CreativeAttributes.AudioAdUserInitiated }
+                        },
+                        Video = new Video {
+                            BidFloor = 3.00f,
+                            Mimes = new[] { "foo", "bar" },
+                            MinBitrate = 1,
+                            MaxBitrate = 200000,
+                            Pos = Position.Fullscreen,
+                            MinDuration = 15,
+                            MaxDuration = 60,
+                            H = 1080,
+                            W = 1920
+                        },
+                        Instl = 1,
+                        Secure = 1,
+                        Ext = new ImpExt {
+                            Position = "App Open"
+                        }
+                    }
+                }
+            };
 
-	public struct ValidateBidRequestTableData {
-		public readonly string Name;
-		public readonly BidRequest Request;
-		public readonly bool WantError;
+            var bidRequestGot = JsonConvert.DeserializeObject<BidRequest>(expected);
+            var jsonStringGot = JsonConvert.SerializeObject(bidRequestGot);
+            var jsonStringWant = JsonConvert.SerializeObject(bidRequestWant);
+            var json1 = JObject.Parse(jsonStringGot);
+            var json2 = JObject.Parse(jsonStringWant);
+            Assert.IsTrue(JToken.DeepEquals(json1, json2));
+        }
+    }
 
-		public ValidateBidRequestTableData(string name, BidRequest request, bool wantError) {
-			Name = name;
-			Request = request;
-			WantError = wantError;
-		}
-	}
+    public struct ValidateBidRequestTableData {
+        public readonly string Name;
+        public readonly BidRequest Request;
+        public readonly bool WantError;
+
+        public ValidateBidRequestTableData(string name, BidRequest request, bool wantError) {
+            Name = name;
+            Request = request;
+            WantError = wantError;
+        }
+    }
 }

--- a/csharp/OpenRTB/Enumerations/Api.cs
+++ b/csharp/OpenRTB/Enumerations/Api.cs
@@ -1,11 +1,11 @@
 namespace OpenRTB.Enumerations {
-	public enum Api : byte {
-		Vpaid = 1,
-		Vpaid2 = 2,
-		Mraid1 = 3,
-		Ormma = 4,
-		Mraid2 = 5,
-		Mraid3 = 6,
-		Omid = 7
-	}
+    public enum Api : byte {
+        Vpaid = 1,
+        Vpaid2 = 2,
+        Mraid1 = 3,
+        Ormma = 4,
+        Mraid2 = 5,
+        Mraid3 = 6,
+        Omid = 7
+    }
 }

--- a/csharp/OpenRTB/Enumerations/CompanionTypes.cs
+++ b/csharp/OpenRTB/Enumerations/CompanionTypes.cs
@@ -1,7 +1,7 @@
 namespace OpenRTB.Enumerations {
-	public enum CompanionTypes : byte {
-		Static = 1,
-		Html = 2,
-		Iframe = 3
-	}
+    public enum CompanionTypes : byte {
+        Static = 1,
+        Html = 2,
+        Iframe = 3
+    }
 }

--- a/csharp/OpenRTB/Enumerations/ConnectionType.cs
+++ b/csharp/OpenRTB/Enumerations/ConnectionType.cs
@@ -1,12 +1,12 @@
 namespace OpenRTB.Enumerations {
-	public enum ConnectionType : byte {
-		Unknown = 0,
-		Ethernet = 1,
-		Wifi = 2,
-		CellularUnknown = 3,
-		Cellular2G = 4,
-		Cellular3G = 5,
-		Cellular4G = 6,
-		Cellular5G = 7
-	}
+    public enum ConnectionType : byte {
+        Unknown = 0,
+        Ethernet = 1,
+        Wifi = 2,
+        CellularUnknown = 3,
+        Cellular2G = 4,
+        Cellular3G = 5,
+        Cellular4G = 6,
+        Cellular5G = 7
+    }
 }

--- a/csharp/OpenRTB/Enumerations/CreativeAttributes.cs
+++ b/csharp/OpenRTB/Enumerations/CreativeAttributes.cs
@@ -1,21 +1,21 @@
 namespace OpenRTB.Enumerations {
-	public enum CreativeAttributes : byte {
-		AudioAdAutoPlay = 1,
-		AudioAdUserInitiated = 2,
-		ExpandableAutomatic = 3,
-		ExpandableUserClick = 4,
-		ExpandableUserRollover = 5,
-		BannerVideoAutoPlay = 6,
-		BannerVideoUserInitiated = 7,
-		HasPopup = 8,
-		ProvocativeOrSuggestive = 9,
-		ExtremeAnimation = 10,
-		Surveys = 11,
-		TextOnly = 12,
-		UserInteractiveAndGames = 13,
-		DialogOrAlertStyle = 14,
-		HasVolumeToggle = 15,
-		HasSkipButton = 16,
-		AdobeFlash = 17
-	}
+    public enum CreativeAttributes : byte {
+        AudioAdAutoPlay = 1,
+        AudioAdUserInitiated = 2,
+        ExpandableAutomatic = 3,
+        ExpandableUserClick = 4,
+        ExpandableUserRollover = 5,
+        BannerVideoAutoPlay = 6,
+        BannerVideoUserInitiated = 7,
+        HasPopup = 8,
+        ProvocativeOrSuggestive = 9,
+        ExtremeAnimation = 10,
+        Surveys = 11,
+        TextOnly = 12,
+        UserInteractiveAndGames = 13,
+        DialogOrAlertStyle = 14,
+        HasVolumeToggle = 15,
+        HasSkipButton = 16,
+        AdobeFlash = 17
+    }
 }

--- a/csharp/OpenRTB/Enumerations/DeliveryMethods.cs
+++ b/csharp/OpenRTB/Enumerations/DeliveryMethods.cs
@@ -1,7 +1,7 @@
 namespace OpenRTB.Enumerations {
-	public enum DeliveryMethods : byte {
-		Streaming = 1,
-		Progressive = 2,
-		Download = 3
-	}
+    public enum DeliveryMethods : byte {
+        Streaming = 1,
+        Progressive = 2,
+        Download = 3
+    }
 }

--- a/csharp/OpenRTB/Enumerations/DeviceType.cs
+++ b/csharp/OpenRTB/Enumerations/DeviceType.cs
@@ -1,11 +1,11 @@
 namespace OpenRTB.Enumerations {
-	public enum DeviceType : byte {
-		MobileTablet = 1,
-		PersonalComputer = 2,
-		ConnectedTv = 3,
-		Phone = 4,
-		Tablet = 5,
-		ConnectedDevice = 6,
-		SetTopBox = 7
-	}
+    public enum DeviceType : byte {
+        MobileTablet = 1,
+        PersonalComputer = 2,
+        ConnectedTv = 3,
+        Phone = 4,
+        Tablet = 5,
+        ConnectedDevice = 6,
+        SetTopBox = 7
+    }
 }

--- a/csharp/OpenRTB/Enumerations/Linearity.cs
+++ b/csharp/OpenRTB/Enumerations/Linearity.cs
@@ -1,6 +1,6 @@
 namespace OpenRTB.Enumerations {
-	public enum Linearity : byte {
-		Linear = 1,
-		NonLinear = 2
-	}
+    public enum Linearity : byte {
+        Linear = 1,
+        NonLinear = 2
+    }
 }

--- a/csharp/OpenRTB/Enumerations/LocationType.cs
+++ b/csharp/OpenRTB/Enumerations/LocationType.cs
@@ -1,7 +1,7 @@
 namespace OpenRTB.Enumerations {
-	public enum LocationType : byte {
-		Gps = 1,
-		IpLookup = 2,
-		UserProvided = 3
-	}
+    public enum LocationType : byte {
+        Gps = 1,
+        IpLookup = 2,
+        UserProvided = 3
+    }
 }

--- a/csharp/OpenRTB/Enumerations/PlacementType.cs
+++ b/csharp/OpenRTB/Enumerations/PlacementType.cs
@@ -1,9 +1,9 @@
 namespace OpenRTB.Enumerations {
-	public enum PlacementType : byte {
-		InStream = 1,
-		InBanner = 2,
-		InArticle = 3,
-		InFeed = 4,
-		InterstitialSliderFloating = 5
-	}
+    public enum PlacementType : byte {
+        InStream = 1,
+        InBanner = 2,
+        InArticle = 3,
+        InFeed = 4,
+        InterstitialSliderFloating = 5
+    }
 }

--- a/csharp/OpenRTB/Enumerations/PlaybackMethods.cs
+++ b/csharp/OpenRTB/Enumerations/PlaybackMethods.cs
@@ -1,10 +1,10 @@
 namespace OpenRTB.Enumerations {
-	public enum PlaybackMethods : byte {
-		PageLoadSoundOn = 1,
-		PageLoadSoundOff = 2,
-		ClickSoundOn = 3,
-		MouseOverSoundOn = 4,
-		EnterViewportSoundOn = 5,
-		EnterViewportSoundOff = 6
-	}
+    public enum PlaybackMethods : byte {
+        PageLoadSoundOn = 1,
+        PageLoadSoundOff = 2,
+        ClickSoundOn = 3,
+        MouseOverSoundOn = 4,
+        EnterViewportSoundOn = 5,
+        EnterViewportSoundOff = 6
+    }
 }

--- a/csharp/OpenRTB/Enumerations/Position.cs
+++ b/csharp/OpenRTB/Enumerations/Position.cs
@@ -1,11 +1,11 @@
 namespace OpenRTB.Enumerations {
-	public enum Position : byte {
-		Unknown = 0,
-		AboveTheFold = 1,
-		BelowTheFold = 3,
-		Header = 4,
-		Footer = 5,
-		Sidebar = 6,
-		Fullscreen = 7
-	}
+    public enum Position : byte {
+        Unknown = 0,
+        AboveTheFold = 1,
+        BelowTheFold = 3,
+        Header = 4,
+        Footer = 5,
+        Sidebar = 6,
+        Fullscreen = 7
+    }
 }

--- a/csharp/OpenRTB/Enumerations/Protocols.cs
+++ b/csharp/OpenRTB/Enumerations/Protocols.cs
@@ -1,8 +1,8 @@
 namespace OpenRTB.Enumerations {
-	public enum Protocols {
-		Vast2 = 2,
-		Vast3 = 3,
-		Vast2Wrapper = 5,
-		Vast3Wrapper = 6
-	}
+    public enum Protocols {
+        Vast2 = 2,
+        Vast3 = 3,
+        Vast2Wrapper = 5,
+        Vast3Wrapper = 6
+    }
 }

--- a/csharp/OpenRTB/OpenRTB.csproj
+++ b/csharp/OpenRTB/OpenRTB.csproj
@@ -71,6 +71,7 @@
         <Compile Include="Request\User.cs" />
         <Compile Include="Request\Video.cs" />
         <Compile Include="Response\BidResponse.cs" />
+        <Compile Include="Response\ErrResponse.cs" />
         <Compile Include="Response\SkadnResponse.cs" />
         <Compile Include="Response\Trackers.cs" />
     </ItemGroup>

--- a/csharp/OpenRTB/Request/App.cs
+++ b/csharp/OpenRTB/Request/App.cs
@@ -1,36 +1,36 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct App {
-		[JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Name { get; set; }
+    public class App {
+        [JsonProperty("bundle", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Bundle;
 
-		[JsonProperty("bundle", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Bundle { get; set; }
+        [JsonProperty("cat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] Cat;
 
-		[JsonProperty("domain", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Domain { get; set; }
+        [JsonProperty("domain", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Domain;
 
-		[JsonProperty("storeurl", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string StoreUrl { get; set; }
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name;
 
-		[JsonProperty("cat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] Cat { get; set; }
+        [JsonProperty("pagecat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] PageCat;
 
-		[JsonProperty("sectioncat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] SectionCat { get; set; }
+        [JsonProperty("paid")] public int Paid;
 
-		[JsonProperty("pagecat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] PageCat { get; set; }
+        [JsonProperty("privacypolicy")] public int PrivacyPolicy;
 
-		[JsonProperty("ver", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Ver { get; set; }
+        [JsonProperty("publisher", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Publisher Publisher;
 
-		[JsonProperty("privacypolicy")] public int PrivacyPolicy { get; set; }
+        [JsonProperty("sectioncat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] SectionCat;
 
-		[JsonProperty("paid")] public int Paid { get; set; }
+        [JsonProperty("storeurl", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string StoreUrl;
 
-		[JsonProperty("publisher", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Publisher Publisher { get; set; }
-	}
+        [JsonProperty("ver", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Ver;
+    }
 }

--- a/csharp/OpenRTB/Request/Banner.cs
+++ b/csharp/OpenRTB/Request/Banner.cs
@@ -2,29 +2,29 @@ using Newtonsoft.Json;
 using OpenRTB.Enumerations;
 
 namespace OpenRTB.Request {
-	public struct Banner {
-		[JsonProperty("bidfloor", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public float BidFloor { set; get; }
+    public class Banner {
+        [JsonProperty("api", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Api[] Api;
 
-		[JsonProperty("battr", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public CreativeAttributes[] BAttr { set; get; }
+        [JsonProperty("format", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Format[] Format;
 
-		[JsonProperty("format", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Format[] Format { get; set; }
+        [JsonProperty("h", Required = Required.Always)]
+        public int? H;
 
-		[JsonProperty("w", Required = Required.Always)]
-		public int? W { get; set; }
+        [JsonProperty("pos", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Position Pos;
 
-		[JsonProperty("h", Required = Required.Always)]
-		public int? H { get; set; }
+        [JsonProperty("vcm", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Vcm;
 
-		[JsonProperty("pos", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Position Pos { get; set; }
+        [JsonProperty("w", Required = Required.Always)]
+        public int? W;
 
-		[JsonProperty("api", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Api[] Api { get; set; }
+        [JsonProperty("bidfloor", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float BidFloor;
 
-		[JsonProperty("vcm", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Vcm { get; set; }
-	}
+        [JsonProperty("battr", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public CreativeAttributes[] BAttr;
+    }
 }

--- a/csharp/OpenRTB/Request/BidRequest.cs
+++ b/csharp/OpenRTB/Request/BidRequest.cs
@@ -1,57 +1,58 @@
 ﻿using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct BidRequest {
-		[JsonProperty("imp", Required = Required.Always)]
-		public Imp[] Imp { get; set; }
+    public class BidRequest {
+        [JsonProperty("app", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public App App;
 
-		[JsonProperty("app", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public App App { get; set; }
+        [JsonProperty("badv", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] BAdv;
 
-		[JsonProperty("device", Required = Required.Always)]
-		public Device Device { get; set; }
+        [JsonProperty("bapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] BApp;
 
-		[JsonProperty("format", Required = Required.Always)]
-		public Format Format { get; set; }
+        [JsonProperty("bcat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] BCat;
 
-		[JsonProperty("user", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public User User { get; set; }
+        [JsonProperty("wlang", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] BLang;
 
-		[JsonProperty("test")] public int Test { get; set; }
+        [JsonProperty("bseat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] BSeat;
 
-		[JsonProperty("wseat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] WSeat { get; set; }
+        [JsonProperty("device", Required = Required.Always)]
+        public Device Device;
 
-		[JsonProperty("bseat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] BSeat { get; set; }
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public BidRequestExt Ext;
 
-		[JsonProperty("wlang", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] BLang { get; set; }
+        [JsonProperty("format", Required = Required.Always)]
+        public Format Format;
 
-		[JsonProperty("bcat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] BCat { get; set; }
+        [JsonProperty("imp", Required = Required.Always)]
+        public Imp[] Imp;
 
-		[JsonProperty("badv", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] BAdv { get; set; }
+        [JsonProperty("regs", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Regs Regs;
 
-		[JsonProperty("bapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] BApp { get; set; }
+        [JsonProperty("source", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Source Source;
 
-		[JsonProperty("source", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Source Source { get; set; }
+        [JsonProperty("test")] public int Test;
 
-		[JsonProperty("regs", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Regs Regs { get; set; }
+        [JsonProperty("user", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public User User;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public BidRequestExt Ext { get; set; }
-	}
+        [JsonProperty("wseat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] WSeat;
+    }
 
-	public class BidRequestExt {
-		[JsonProperty("api_key", Required = Required.Always)]
-		public string ApiKey { get; set; }
+    public class BidRequestExt {
+        // this is required, however servers are allowed to send this in a header to Nimbus
+        [JsonProperty("api_key", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string ApiKey;
 
-		[JsonProperty("session_id", Required = Required.Always)]
-		public string SessionId { get; set; }
-	}
+        [JsonProperty("session_id", Required = Required.Always)]
+        public string SessionId;
+    }
 }

--- a/csharp/OpenRTB/Request/Data.cs
+++ b/csharp/OpenRTB/Request/Data.cs
@@ -1,14 +1,14 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Data {
-		[JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Id { get; set; }
+    public class Data {
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Id;
 
-		[JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Name { get; set; }
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name;
 
-		[JsonProperty("segment", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Segment[] Segment { get; set; }
-	}
+        [JsonProperty("segment", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Segment[] Segment;
+    }
 }

--- a/csharp/OpenRTB/Request/Device.cs
+++ b/csharp/OpenRTB/Request/Device.cs
@@ -2,63 +2,64 @@ using Newtonsoft.Json;
 using OpenRTB.Enumerations;
 
 namespace OpenRTB.Request {
-	public struct Device {
-		[JsonProperty("ua", Required = Required.Always)]
-		public string Ua { get; set; }
+    public class Device {
+        [JsonProperty("carrier", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Carrier;
 
-		[JsonProperty("geo", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Geo Geo { get; set; }
+        [JsonProperty("connectiontype")] public ConnectionType ConnectionType;
 
-		[JsonProperty("dnt")] public int Dnt { get; set; }
-		[JsonProperty("lmt")] public int Lmt { get; set; }
+        [JsonProperty("devicetype", Required = Required.Always)]
+        public DeviceType? DeviceType;
 
-		[JsonProperty("ip", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Ip { get; set; }
+        [JsonProperty("dnt")] public int Dnt;
 
-		[JsonProperty("devicetype", Required = Required.Always)]
-		public DeviceType? DeviceType { get; set; }
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DeviceExt Ext;
 
-		[JsonProperty("make", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Make { get; set; }
+        [JsonProperty("geo", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Geo Geo;
 
-		[JsonProperty("model", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Model { get; set; }
+        [JsonProperty("h", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int H;
 
-		[JsonProperty("hwv", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Hwv { get; set; }
+        [JsonProperty("hwv", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Hwv;
 
-		[JsonProperty("os", Required = Required.Always)]
-		public string Os { get; set; }
+        [JsonProperty("ifa", Required = Required.Always)]
+        public string Ifa;
 
-		[JsonProperty("osv", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Osv { get; set; }
+        [JsonProperty("ip", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Ip;
 
-		[JsonProperty("h", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int H { get; set; }
+        [JsonProperty("language", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Language;
 
-		[JsonProperty("w", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int W { get; set; }
+        [JsonProperty("lmt")] public int Lmt;
 
-		[JsonProperty("language", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Language { get; set; }
+        [JsonProperty("make", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Make;
 
-		[JsonProperty("carrier", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Carrier { get; set; }
+        [JsonProperty("model", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Model;
 
-		[JsonProperty("connectiontype")] public ConnectionType ConnectionType { get; set; }
+        [JsonProperty("os", Required = Required.Always)]
+        public string Os;
 
-		[JsonProperty("ifa", Required = Required.Always)]
-		public string Ifa { get; set; }
+        [JsonProperty("osv", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Osv;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public DeviceExt Ext { get; set; }
-	}
+        [JsonProperty("ua", Required = Required.Always)]
+        public string Ua;
 
-	public struct DeviceExt {
-		[JsonProperty("atts", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Atts { get; set; }
+        [JsonProperty("w", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int W;
+    }
 
-		[JsonProperty("ifv", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Ifv { get; set; }
-	}
+    public class DeviceExt {
+        [JsonProperty("atts", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Atts;
+
+        [JsonProperty("ifv", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Ifv;
+    }
 }

--- a/csharp/OpenRTB/Request/Eid.cs
+++ b/csharp/OpenRTB/Request/Eid.cs
@@ -1,24 +1,24 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Eid {
-		[JsonProperty("source", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Source { get; set; }
+    public class Eid {
+        [JsonProperty("source", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Source;
 
-		[JsonProperty("uids", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Uid[] Uids { get; set; }
-	}
+        [JsonProperty("uids", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Uid[] Uids;
+    }
 
-	public struct Uid {
-		[JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Id { get; set; }
+    public class Uid {
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Id;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public UidExt UidExt { get; set; }
-	}
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public UidExt UidExt;
+    }
 
-	public struct UidExt {
-		[JsonProperty("rtiPartner", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string RtiPartner { get; set; }
-	}
+    public class UidExt {
+        [JsonProperty("rtiPartner", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string RtiPartner;
+    }
 }

--- a/csharp/OpenRTB/Request/Format.cs
+++ b/csharp/OpenRTB/Request/Format.cs
@@ -1,11 +1,11 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Format {
-		[JsonProperty("w", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int W { get; set; }
+    public class Format {
+        [JsonProperty("h", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int H;
 
-		[JsonProperty("h", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int H { get; set; }
-	}
+        [JsonProperty("w", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int W;
+    }
 }

--- a/csharp/OpenRTB/Request/Geo.cs
+++ b/csharp/OpenRTB/Request/Geo.cs
@@ -1,29 +1,29 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Geo {
-		[JsonProperty("lat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public float Lat { get; set; }
+    public class Geo {
+        [JsonProperty("city", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string City;
 
-		[JsonProperty("lon", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public float Lon { get; set; }
+        [JsonProperty("country", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Country;
 
-		[JsonProperty("type", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Type { get; set; }
+        [JsonProperty("ipservice", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int IpService;
 
-		[JsonProperty("ipservice", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int IpService { get; set; }
+        [JsonProperty("lat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float Lat;
 
-		[JsonProperty("country", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Country { get; set; }
+        [JsonProperty("lon", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float Lon;
 
-		[JsonProperty("city", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string City { get; set; }
+        [JsonProperty("metro", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Metro;
 
-		[JsonProperty("metro", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Metro { get; set; }
+        [JsonProperty("state", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string State;
 
-		[JsonProperty("state", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string State { get; set; }
-	}
+        [JsonProperty("type", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Type;
+    }
 }

--- a/csharp/OpenRTB/Request/Imp.cs
+++ b/csharp/OpenRTB/Request/Imp.cs
@@ -1,30 +1,30 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Imp {
-		[JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Id { get; set; }
+    public class Imp {
+        [JsonProperty("banner", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Banner Banner;
 
-		[JsonProperty("banner", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Banner Banner { get; set; }
+        [JsonProperty("ext", Required = Required.Always)]
+        public ImpExt Ext;
 
-		[JsonProperty("video", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Video Video { get; set; }
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Id;
 
-		[JsonProperty("instl")] public int Instl { get; set; }
+        [JsonProperty("instl")] public int Instl;
 
-		[JsonProperty("secure", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Secure { get; set; }
+        [JsonProperty("secure", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Secure;
 
-		[JsonProperty("ext", Required = Required.Always)]
-		public ImpExt Ext { get; set; }
-	}
+        [JsonProperty("video", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Video Video;
+    }
 
-	public struct ImpExt {
-		[JsonProperty("position", Required = Required.Always)]
-		public string Position { get; set; }
+    public class ImpExt {
+        [JsonProperty("position", Required = Required.Always)]
+        public string Position;
 
-		[JsonProperty("skadn", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Skadn Skadn { get; set; }
-	}
+        [JsonProperty("skadn", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Skadn Skadn;
+    }
 }

--- a/csharp/OpenRTB/Request/Publisher.cs
+++ b/csharp/OpenRTB/Request/Publisher.cs
@@ -1,14 +1,14 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Publisher {
-		[JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Name { get; set; }
+    public class Publisher {
+        [JsonProperty("cat", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] Cat;
 
-		[JsonProperty("cat", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] Cat { get; set; }
+        [JsonProperty("domain", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Domain;
 
-		[JsonProperty("domain", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Domain { get; set; }
-	}
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name;
+    }
 }

--- a/csharp/OpenRTB/Request/Regs.cs
+++ b/csharp/OpenRTB/Request/Regs.cs
@@ -1,18 +1,18 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Regs {
-		[JsonProperty("coppa")] public int Coppa { get; set; }
+    public class Regs {
+        [JsonProperty("coppa")] public int Coppa;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public RegExt Ext { get; set; }
-	}
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public RegExt Ext;
+    }
 
-	public struct RegExt {
-		[JsonProperty("gdpr", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Gdpr { get; set; }
+    public class RegExt {
+        [JsonProperty("gdpr", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Gdpr;
 
-		[JsonProperty("us_privacy", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string UsPrivacy { get; set; }
-	}
+        [JsonProperty("us_privacy", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string UsPrivacy;
+    }
 }

--- a/csharp/OpenRTB/Request/Segment.cs
+++ b/csharp/OpenRTB/Request/Segment.cs
@@ -1,14 +1,14 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Segment {
-		[JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Id { get; set; }
+    public class Segment {
+        [JsonProperty("id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Id;
 
-		[JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Name { get; set; }
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name;
 
-		[JsonProperty("value", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Value { get; set; }
-	}
+        [JsonProperty("value", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Value;
+    }
 }

--- a/csharp/OpenRTB/Request/Skadn.cs
+++ b/csharp/OpenRTB/Request/Skadn.cs
@@ -1,14 +1,14 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Skadn {
-		[JsonProperty("version", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Version { get; set; }
+    public class Skadn {
+        [JsonProperty("skadnetids", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] SkadnetIds;
 
-		[JsonProperty("sourceapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string SourceApp { get; set; }
+        [JsonProperty("sourceapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string SourceApp;
 
-		[JsonProperty("skadnetids", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] SkadnetIds { get; set; }
-	}
+        [JsonProperty("version", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Version;
+    }
 }

--- a/csharp/OpenRTB/Request/Source.cs
+++ b/csharp/OpenRTB/Request/Source.cs
@@ -1,16 +1,16 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct Source {
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public SourceExt Ext { get; set; }
-	}
+    public class Source {
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public SourceExt Ext;
+    }
 
-	public struct SourceExt {
-		[JsonProperty("omidpn", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Omidpn { get; set; }
+    public class SourceExt {
+        [JsonProperty("omidpn", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Omidpn;
 
-		[JsonProperty("omidpv", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Omidpv { get; set; }
-	}
+        [JsonProperty("omidpv", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Omidpv;
+    }
 }

--- a/csharp/OpenRTB/Request/User.cs
+++ b/csharp/OpenRTB/Request/User.cs
@@ -1,39 +1,39 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Request {
-	public struct User {
-		[JsonProperty("age", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Age { get; set; }
+    public class User {
+        [JsonProperty("age", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Age;
 
-		[JsonProperty("buyeruid", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string BuyerId { get; set; }
+        [JsonProperty("buyeruid", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string BuyerId;
 
-		[JsonProperty("yob", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Yob { get; set; }
+        [JsonProperty("custom_data", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string CustomData;
 
-		[JsonProperty("gender", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Gender { get; set; }
+        [JsonProperty("data", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Data Data;
 
-		[JsonProperty("keywords", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Keywords { get; set; }
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public UserExt Ext;
 
-		[JsonProperty("custom_data", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string CustomData { get; set; }
+        [JsonProperty("gender", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Gender;
 
-		[JsonProperty("data", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Data Data { get; set; }
+        [JsonProperty("keywords", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Keywords;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public UserExt Ext { get; set; }
-	}
+        [JsonProperty("yob", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Yob;
+    }
 
-	public struct UserExt {
-		[JsonProperty("consent", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Consent { get; set; }
+    public class UserExt {
+        [JsonProperty("consent", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Consent;
 
-		[JsonProperty("did_consent")] public int DidConsent { get; set; }
+        [JsonProperty("did_consent")] public int DidConsent;
 
-		[JsonProperty("eids", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Eid[] Eids { get; set; }
-	}
+        [JsonProperty("eids", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Eid[] Eids;
+    }
 }

--- a/csharp/OpenRTB/Request/Video.cs
+++ b/csharp/OpenRTB/Request/Video.cs
@@ -2,66 +2,66 @@ using Newtonsoft.Json;
 using OpenRTB.Enumerations;
 
 namespace OpenRTB.Request {
-	public struct Video {
-		[JsonProperty("bidfloor", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public float BidFloor { set; get; }
+    public class Video {
+        [JsonProperty("api", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Api[] Api;
 
-		[JsonProperty("companionad", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Banner[] CompanionAd { set; get; }
+        [JsonProperty("delivery", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public DeliveryMethods[] Delivery;
 
-		[JsonProperty("companiontype", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public CompanionTypes[] CompanionType { set; get; }
+        [JsonProperty("ext", NullValueHandling = NullValueHandling.Ignore)]
+        public VideoExt Ext;
 
-		[JsonProperty("mimes", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] Mimes { get; set; }
+        [JsonProperty("h", Required = Required.Always)]
+        public int? H;
 
-		[JsonProperty("minduration", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int MinDuration { get; set; }
+        [JsonProperty("linearity", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Linearity Linearity;
 
-		[JsonProperty("maxduration", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int MaxDuration { get; set; }
+        [JsonProperty("maxbitrate", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MaxBitrate;
 
-		[JsonProperty("protocols", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Protocols[] Protocols { get; set; }
+        [JsonProperty("maxduration", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MaxDuration;
 
-		[JsonProperty("w", Required = Required.Always)]
-		public int? W { get; set; }
+        [JsonProperty("mimes", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] Mimes;
 
-		[JsonProperty("h", Required = Required.Always)]
-		public int? H { get; set; }
+        [JsonProperty("minbitrate", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MinBitrate;
 
-		[JsonProperty("startdelay")] public int StartDelay { get; set; }
+        [JsonProperty("minduration", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int MinDuration;
 
-		[JsonProperty("placement", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public PlacementType Placement { get; set; }
+        [JsonProperty("placement", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public PlacementType Placement;
 
-		[JsonProperty("linearity", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Linearity Linearity { get; set; }
+        [JsonProperty("playbackmethod", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public PlaybackMethods[] PlaybackMethod;
 
-		[JsonProperty("playbackmethod", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public PlaybackMethods[] PlaybackMethod { get; set; }
+        [JsonProperty("pos")] public Position Pos;
 
-		[JsonProperty("skip")] public int Skip { get; set; }
+        [JsonProperty("protocols", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Protocols[] Protocols;
 
-		[JsonProperty("delivery", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public DeliveryMethods[] Delivery { get; set; }
+        [JsonProperty("skip")] public int Skip;
 
-		[JsonProperty("pos")] public Position Pos { get; set; }
+        [JsonProperty("startdelay")] public int StartDelay;
 
-		[JsonProperty("api", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Api[] Api { get; set; }
+        [JsonProperty("w", Required = Required.Always)]
+        public int? W;
 
-		[JsonProperty("minbitrate", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int MinBitrate { get; set; }
+        [JsonProperty("bidfloor", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public float BidFloor;
 
-		[JsonProperty("maxbitrate", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int MaxBitrate { get; set; }
+        [JsonProperty("companionad", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Banner[] CompanionAd;
 
-		[JsonProperty("ext", NullValueHandling = NullValueHandling.Ignore)]
-		public VideoExt Ext { get; set; }
-	}
+        [JsonProperty("companiontype", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public CompanionTypes[] CompanionType;
+    }
 
-	public struct VideoExt {
-		[JsonProperty("is_rewarded")] public int IsRewarded { get; set; }
-	}
+    public class VideoExt {
+        [JsonProperty("is_rewarded")] public int IsRewarded;
+    }
 }

--- a/csharp/OpenRTB/Response/BidResponse.cs
+++ b/csharp/OpenRTB/Response/BidResponse.cs
@@ -1,46 +1,47 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Response {
-	public struct BidResponse {
-		[JsonProperty("type")] public string Type { get; set; }
-		[JsonProperty("auction_id")] public string AuctionId { get; set; }
+    public struct BidResponse {
+        [JsonProperty("type")] public string Type;
+        [JsonProperty("auction_id")] public string AuctionId;
 
-		[JsonProperty("adomain", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] Adomain { get; set; }
+        [JsonProperty("adomain", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] Adomain;
 
-		[JsonProperty("bid_in_cents")] public int BidInCents { get; set; }
-		[JsonProperty("bid_raw")] public float BidRaw { get; set; }
-		[JsonProperty("content_type")] public string ContentType { get; set; }
+        [JsonProperty("bid_in_cents")] public int BidInCents;
+        [JsonProperty("bid_raw")] public float BidRaw;
+        [JsonProperty("content_type")] public string ContentType;
 
-		[JsonProperty("crid", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Crid { get; set; }
+        [JsonProperty("crid", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Crid;
 
-		[JsonProperty("height", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Height { get; set; }
+        [JsonProperty("height", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Height;
 
-		[JsonProperty("width", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Width { get; set; }
+        [JsonProperty("width", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Width;
 
-		[JsonProperty("is_interstitial")] public int IsInterstitial { get; set; }
-		[JsonProperty("is_mraid")] public int IsMraid { get; set; }
-		[JsonProperty("markup")] public string Markup { get; set; }
-		[JsonProperty("network")] public string Network { get; set; }
+        [JsonProperty("is_interstitial")] public int IsInterstitial;
+        [JsonProperty("is_mraid")] public int IsMraid;
+        [JsonProperty("markup")] public string Markup;
+        [JsonProperty("network")] public string Network;
+        [JsonProperty("position")] public string Position;
 
-		[JsonProperty("trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public Trackers[] Trackers { get; set; }
+        [JsonProperty("trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public Trackers Trackers;
 
-		[JsonProperty("placement_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string PlacementId { get; set; }
+        [JsonProperty("placement_id", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string PlacementId;
 
-		[JsonProperty("duration", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public int Duration { get; set; }
+        [JsonProperty("duration", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public int Duration;
 
-		[JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public BidExt Ext { get; set; }
-	}
+        [JsonProperty("ext", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public BidExt Ext;
+    }
 
-	public struct BidExt {
-		[JsonProperty("skadn", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public SkadnResponse Skadn { get; set; }
-	}
+    public struct BidExt {
+        [JsonProperty("skadn", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public SkadnResponse Skadn;
+    }
 }

--- a/csharp/OpenRTB/Response/ErrResponse.cs
+++ b/csharp/OpenRTB/Response/ErrResponse.cs
@@ -1,0 +1,10 @@
+using Newtonsoft.Json;
+
+namespace OpenRTB.Response {
+    public struct ErrResponse {
+        [JsonProperty("id")] public string Id;
+        [JsonProperty("status_code")] public int StatusCode;
+        [JsonProperty("nbr")] public int Nrb;
+        [JsonProperty("message")] public string Message;
+    }
+}

--- a/csharp/OpenRTB/Response/SkadnResponse.cs
+++ b/csharp/OpenRTB/Response/SkadnResponse.cs
@@ -1,29 +1,29 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Response {
-	public struct SkadnResponse {
-		[JsonProperty("version", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Version { get; set; }
+    public struct SkadnResponse {
+        [JsonProperty("version", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Version;
 
-		[JsonProperty("network", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Network { get; set; }
+        [JsonProperty("network", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Network;
 
-		[JsonProperty("campaign", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Campaign { get; set; }
+        [JsonProperty("campaign", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Campaign;
 
-		[JsonProperty("itunesitem", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Itunesitem { get; set; }
+        [JsonProperty("itunesitem", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Itunesitem;
 
-		[JsonProperty("nonce", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Nonce { get; set; }
+        [JsonProperty("nonce", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Nonce;
 
-		[JsonProperty("sourceapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Sourceapp { get; set; }
+        [JsonProperty("sourceapp", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Sourceapp;
 
-		[JsonProperty("timestamp", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Timestamp { get; set; }
+        [JsonProperty("timestamp", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Timestamp;
 
-		[JsonProperty("signature", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string Signature { get; set; }
-	}
+        [JsonProperty("signature", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Signature;
+    }
 }

--- a/csharp/OpenRTB/Response/Trackers.cs
+++ b/csharp/OpenRTB/Response/Trackers.cs
@@ -1,11 +1,11 @@
 using Newtonsoft.Json;
 
 namespace OpenRTB.Response {
-	public struct Trackers {
-		[JsonProperty("impression_trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] ImpressionTrackers { get; set; }
+    public struct Trackers {
+        [JsonProperty("impression_trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] ImpressionTrackers;
 
-		[JsonProperty("click_trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
-		public string[] ClickTrackers { get; set; }
-	}
+        [JsonProperty("click_trackers", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string[] ClickTrackers;
+    }
 }


### PR DESCRIPTION
Because this lib is intended to be used within the Unity Game Engine context, Method Properties do not serialize on IOS builds and classes are used over structs to provide convenient extension methods downstream

- In order to create proper builders and setters its easier to work with classes rather than creating new structs for each modification
- Running Code formatters