### PR TITLE
Added generic ext field to all OpenRTB objects

### DIFF
--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/App.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/App.kt
@@ -28,6 +28,7 @@ import kotlin.jvm.JvmField
  * @property privacypolicy Indicates if the app has a privacy policy. (0 = No, 1 = Yes)
  * @property paid Indicates if the app is free or paid. (0 = Free, 1 = Paid)
  * @property publisher Details about the publisher of the app.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
 public class App(
@@ -43,4 +44,5 @@ public class App(
     @JvmField @SerialName("privacypolicy") public var privacypolicy: Byte? = null,
     @JvmField @SerialName("paid") public var paid: Byte? = null,
     @JvmField @SerialName("publisher") public var publisher: Publisher? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Banner.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Banner.kt
@@ -28,6 +28,7 @@ import kotlin.jvm.JvmField
  * @property api Set of supported Api frameworks for this banner impression. If an Api is not
  *               explicitly listed, it is assumed not to be supported.
  * @property vcm The type of companion ad if used in a Video object. (0 - Concurrent, 1 - End Card)
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
 public class Banner(
@@ -39,4 +40,5 @@ public class Banner(
     @JvmField @SerialName("pos") public var pos: Byte = 0,
     @JvmField @SerialName("api") public var api: ByteArray? = null,
     @JvmField @SerialName("vcm") public var vcm: Byte? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
@@ -29,7 +29,7 @@ public typealias Extension = JsonObject
  *
  * @property imp Array of impression objects representing the impressions offered.
  *               Only 1 impression object is supported.
- *  @property app Details about the publisher’s app (i.e., non-browser applications).
+ * @property app Details about the publisher’s app (i.e., non-browser applications).
  * @property device Details about the user’s device to which the impression will be delivered.
  * @property format A format object representing the width and height of the device.
  *                  This is not part of the spec, adding this here for convenience allows height and

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
@@ -2,10 +2,17 @@ package com.adsbynimbus.openrtb.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.*
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
+
+/**
+ * Type alias for the ext field present on all OpenRTB objects.
+ *
+ * Extensions defined by Nimbus are implemented as extension properties on the [JsonObject].
+ */
+public typealias Extension = JsonObject
 
 /**
  * The top-level bid request object contains a globally unique bid request or auction ID.
@@ -52,16 +59,8 @@ public class BidRequest(
     @JvmField @SerialName("badv") public var badv: Array<String>? = null,
     @JvmField @SerialName("source") public var source: Source? = null,
     @JvmField @SerialName("regs") public var regs: Regs? = null,
-    @JvmField @SerialName("ext") public val ext: MutableMap<String, String> = mutableMapOf(),
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 ) {
-
-    /**
-     * Any unique string value to identify the session.
-     *
-     * Defaults to a random UUID when using the Nimbus SDK
-     */
-    public var session_id: String by ext
-
     public companion object {
         /** Required header for all requests to Nimbus defining the OpenRTB version */
         public const val OPENRTB_HEADER: String = "x-openrtb-version"
@@ -87,3 +86,25 @@ public class BidRequest(
             jsonSerializer.decodeFromString(serializer(), json)
     }
 }
+
+/** The API key used to authenticate with Nimbus. */
+public var BidRequest.api_key: String?
+    get() = ext?.get("api_key")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("api_key", value)
+        }
+    }
+
+/** Any unique string value to identify the session; when used in the Nimbus SDK will be a UUID */
+public var BidRequest.session_id: String?
+    get() = ext?.get("session_id")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("session_id", value)
+        }
+    }
+
+

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Data.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Data.kt
@@ -17,6 +17,7 @@ import kotlin.jvm.JvmField
  * @property id Exchange-specific ID for the data provider.
  * @property name Exchange-specific name for the data provider.
  * @property segment Array of [Segment] objects that contain the actual data values.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  * @see [OpenRTB Section 3.2.22](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf#page=31)
  */
 @Serializable
@@ -24,4 +25,5 @@ public class Data(
     @JvmField @SerialName("id") public var id: String,
     @JvmField @SerialName("name") public var name: String,
     @JvmField @SerialName("segment") public var segment: Array<Segment>? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Device.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Device.kt
@@ -34,6 +34,7 @@ import kotlin.jvm.JvmField
  *                   should be published to bidders a priori.
  * @property connectiontype Network connection type.
  * @property ifa ID sanctioned for advertiser use in the clear (i.e., not hashed).
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
 public class Device(
@@ -54,4 +55,5 @@ public class Device(
     @JvmField @SerialName("geo") public var geo: Geo? = null,
     @JvmField @SerialName("ip") public var ip: String? = null,
     @JvmField @SerialName("carrier") public var carrier: String? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Geo.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Geo.kt
@@ -29,6 +29,7 @@ import kotlin.jvm.JvmField
  * @property city City using United Nations Code for Trade &amp; Transport Locations.
  * @property metro Google metro code; similar to but not exactly Nielsen DMAs.
  * @property state 2-letter state code.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  * @see [United Nations Location Codes](http://www.unece.org/cefact/locode/service/location.htm)
  * @see [Google Metro codes](code.google.com/apis/adwords/docs/appendix/metrocodes.html)
  */
@@ -42,4 +43,5 @@ public class Geo(
     @JvmField @SerialName("city") public var city: String? = null,
     @JvmField @SerialName("metro") public var metro: String? = null,
     @JvmField @SerialName("state") public var state: String? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Native.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Native.kt
@@ -29,6 +29,7 @@ import kotlin.jvm.JvmField
  * @property api List of supported API frameworks for this impression. If an API is not explicitly
  *               listed, it is assumed not to be supported.
  * @property battr Set of creative attributes to block.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
 public class Native(
@@ -37,4 +38,5 @@ public class Native(
     @JvmField @SerialName("ver") public var ver: String? = null,
     @JvmField @SerialName("api") public var api: ByteArray? = null,
     @JvmField @SerialName("battr") public var battr: ByteArray? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Publisher.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Publisher.kt
@@ -14,6 +14,7 @@ import kotlin.jvm.JvmField
  * @property name Publisher name (may be aliased at the publisher’s request).
  * @property domain Highest level domain of the publisher (e.g., "adsbynimbus.com").
  * @property cat Array of IAB content categories that describe the publisher.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  * @see [OpenRTB Section 5.1](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf#page=39)
  */
 @Serializable
@@ -21,4 +22,5 @@ public class Publisher(
     @JvmField @SerialName("name") public var name: String? = null,
     @JvmField @SerialName("domain") public var domain: String? = null,
     @JvmField @SerialName("cat") public var cat: Array<String>? = null,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Regs.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Regs.kt
@@ -2,6 +2,7 @@ package com.adsbynimbus.openrtb.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
 import kotlin.jvm.JvmField
 
 /**
@@ -17,36 +18,49 @@ import kotlin.jvm.JvmField
  *                 by the USA FTC.
  *                 0 = no
  *                 1 = yes
- * @property ext Regs extension object unique to Nimbus
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  * @see [OpenRTB Section 7.5](https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf#page=76)
  */
 @Serializable
 public class Regs(
     @JvmField @SerialName("coppa") public var coppa: Byte = 0,
-    @JvmField @SerialName("ext") public var ext: Extension = Extension(),
-) {
-    /**
-     * Placeholder for exchange-specific extensions to OpenRTB.
-     *
-     * @property gdpr Flag indication if this request is subject to GDPR regulations. This flag will
-     *                be set automatically by Nimbus based on the received IP address.
-     * @property us_privacy A publisher generated string representing compliance with CCPA.
-     *                      The CCPA privacy string is a 4 character string in the following format:
-     *
-     *                      Integer - Privacy string version.
-     *                      (Y, N, -) - Publisher has provided explicit user notice.
-     *                      (Y, N, -) - User opted out of sale
-     *                      (Y, N, -) - Publisher operating under the Limited Service Provider
-     *                                  Agreement
-     *
-     *                      If the user does not fall within a US Privacy jurisdiction, hyphens
-     *                      should be used in the last three positions, generating this privacy
-     *                      string: "1---"
-     * @see [US Privacy String Format](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/Version%201.0/US%20Privacy%20String.md.us-privacy-string-format)
-     */
-    @Serializable
-    public class Extension(
-        @JvmField @SerialName("gdpr") public var gdpr: Byte = 0,
-        @JvmField @SerialName("us_privacy") public var us_privacy: String? = null
-    )
-}
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
+)
+
+/**
+ * Flag indication if this request is subject to GDPR regulations.
+ *
+ * This flag will be set automatically by Nimbus based on the received IP address.
+ */
+public var Regs.gdpr: Byte?
+    get() = ext?.get("gdpr")?.jsonPrimitive?.intOrNull?.toByte()
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("gdpr", value)
+        }
+    }
+
+/**
+ * A publisher generated string representing compliance with CCPA.
+ *
+ * The CCPA privacy string is a 4 character string in the following format:
+ *
+ * Integer   - Privacy string version.
+ * (Y, N, -) - Publisher has provided explicit user notice.
+ * (Y, N, -) - User opted out of sale
+ * (Y, N, -) - Publisher operating under the Limited Service Provider Agreement
+ *
+ * If the user does not fall within a US Privacy jurisdiction, hyphens should be used in the last
+ * three positions, generating this privacy string: "1---"
+ *
+ * @see [US Privacy String Format](https://github.com/InteractiveAdvertisingBureau/USPrivacy/blob/master/CCPA/Version%201.0/US%20Privacy%20String.md.us-privacy-string-format)
+ */
+public var Regs.us_privacy: String?
+    get() = ext?.get("us_privacy")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("us_privacy", value)
+        }
+    }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Segment.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Segment.kt
@@ -15,10 +15,12 @@ import kotlin.jvm.JvmField
  * @property id ID of the data segment specific to the data provider.
  * @property name Name of the data segment specific to the data provider.
  * @property value String representation of the data segment value.
+ * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
 public class Segment(
     @JvmField @SerialName("id") public val id: String,
     @JvmField @SerialName("name") public val name: String,
     @JvmField @SerialName("value") public val value: String,
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
 )

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Source.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Source.kt
@@ -2,6 +2,10 @@ package com.adsbynimbus.openrtb.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
 import kotlin.jvm.JvmField
 
 /**
@@ -18,13 +22,24 @@ import kotlin.jvm.JvmField
  * @property ext Placeholder for exchange-specific extensions to OpenRTB.
  */
 @Serializable
-public class Source(
-    @JvmField @SerialName("ext") public val ext: MutableMap<String, String> = mutableMapOf()
-) {
+public class Source(@JvmField @SerialName("ext") public var ext: Extension? = null)
 
-    /** Partner name that identifies the OM SDK integration */
-    public var omidpn: String by ext
+/** Partner name that identifies the OM SDK integration. */
+public var Source.omidpn: String?
+    get() = ext?.get("omidpn")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("omidpn", value)
+        }
+    }
 
-    /** Current version of the OM SDK integration */
-    public var omidpv: String by ext
-}
+/** Current version of the OM SDK integration. */
+public var Source.omidpv: String?
+    get() = ext?.get("omidpv")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("omidpv", value)
+        }
+    }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/User.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/User.kt
@@ -2,6 +2,7 @@ package com.adsbynimbus.openrtb.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
 import kotlin.jvm.JvmField
 
 /**
@@ -44,18 +45,49 @@ public class User(
     /**
      * User extension object used by Nimbus
      *
-     * @property consent Publisher provided GDPR consent string
-     * @property did_consent 1 if the user has consented to data tracking, 0 if the user has opted
-     *                       out of data tracking.
-     * @property unity_buyeruid String token provided by the Unity Ads SDK to include Unity demand
-     *                          in the auction. Token is initialized when UnityAds is initialized
-     *                          and the token and campaign is refreshed after the ad playback has
-     *                          started.
+     * @property consent
+     * @property did_consent
+     * @property unity_buyeruid
      */
-    @Serializable
+   /* @Serializable
     public class Extension(
         @JvmField @SerialName("consent") public var consent: String? = null,
         @JvmField @SerialName("did_consent") public var did_consent: Byte? = null,
         @JvmField @SerialName("unity_buyeruid") public var unity_buyeruid: String? = null,
-    )
+    ) */
 }
+
+/** Publisher provided GDPR consent string */
+public var User.consent: String?
+    get() = ext?.get("consent")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("consent", value)
+        }
+    }
+
+/** 1 if the user has consented to data tracking, 0 if the user has opted out of data tracking.*/
+public var User.did_consent: Byte?
+    get() = ext?.get("did_consent")?.jsonPrimitive?.intOrNull?.toByte()
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("did_consent", value)
+        }
+    }
+
+/**
+ * String token provided by the Unity Ads SDK to include Unity demand in the auction.
+ *
+ * Token is initialized when UnityAds is initialized and the token and campaign is refreshed after
+ * the ad playback has started.
+ */
+public var User.unity_buyeruid: String?
+    get() = ext?.get("unity_buyeruid")?.jsonPrimitive?.contentOrNull
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("unity_buyeruid", value)
+        }
+    }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Video.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/Video.kt
@@ -2,6 +2,7 @@ package com.adsbynimbus.openrtb.request
 
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.*
 import kotlin.jvm.JvmField
 
 /**
@@ -79,11 +80,15 @@ public class Video(
     @JvmField @SerialName("api") public var api: ByteArray? = null,
     @JvmField @SerialName("companionad") public var companionad: Array<Banner>? = null,
     @JvmField @SerialName("companiontype") public var companiontype: ByteArray? = null,
-    @JvmField @SerialName("ext") public var ext: MutableMap<String, Byte> = mutableMapOf(
-        "is_rewarded" to 0
-    ),
-) {
+    @JvmField @SerialName("ext") public var ext: Extension? = null,
+)
 
-    /** Indicates this video request is for a rewarded video */
-    public var is_rewarded: Byte by ext
-}
+/** Indicates this video request is for a rewarded video. */
+public var Video.is_rewarded: Byte
+    get() = ext?.get("is_rewarded")?.jsonPrimitive?.int?.toByte() ?: 0
+    set(value) {
+        ext = buildJsonObject {
+            ext?.forEach { put(it.key, it.value) }
+            put("is_rewarded", value)
+        }
+    }

--- a/kotlin/src/commonTest/kotlin/com.adsbynimbus.openrtb.request/DeserializationTest.kt
+++ b/kotlin/src/commonTest/kotlin/com.adsbynimbus.openrtb.request/DeserializationTest.kt
@@ -2,8 +2,6 @@ package com.adsbynimbus.openrtb.request
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldHaveSize
-import io.kotest.matchers.maps.shouldContain
-import io.kotest.matchers.maps.shouldNotBeEmpty
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -151,8 +149,7 @@ class DeserializationTest : StringSpec({
     }
 
     "BidResponse fromJson deserializes the ext object" {
-        request.ext.shouldNotBeEmpty()
-        request.ext.shouldContain("api_key", "12345678-4321-1234-0000-6c5b91b1eac6")
+        request.api_key shouldBe "12345678-4321-1234-0000-6c5b91b1eac6"
         request.session_id shouldBe "session1"
     }
 })

--- a/kotlin/src/commonTest/kotlin/com.adsbynimbus.openrtb.request/ExtensionsTest.kt
+++ b/kotlin/src/commonTest/kotlin/com.adsbynimbus.openrtb.request/ExtensionsTest.kt
@@ -1,0 +1,17 @@
+package com.adsbynimbus.openrtb.request
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+class ExtensionsTest : StringSpec({
+
+    val user = User()
+
+    "When adding values to an Extension, previous values are preserved" {
+        user.unity_buyeruid shouldBe null
+        user.unity_buyeruid = "test_buyer_id"
+        user.consent = "consent_string"
+        user.unity_buyeruid shouldBe "test_buyer_id"
+        user.consent shouldBe "consent_string"
+    }
+})

--- a/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
+++ b/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
@@ -2,7 +2,6 @@ package com.adsbynimbus.openrtb.response
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeIn
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 
 const val testJson = """

--- a/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
+++ b/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
@@ -78,14 +78,22 @@ class DeserializationTest : StringSpec({
     }
 
     "BidResponse fromJson deserializes click_trackers" {
-        "https://test.adsbynimbus.com/click_tracker/" shouldBeIn response.click_trackers
+        "https://test.adsbynimbus.com/click_tracker/" shouldBeIn response.trackers.click
     }
 
     "BidResponse fromJson deserializes impression_trackers" {
-        "https://test.adsbynimbus.com/impression_tracker/" shouldBeIn response.impression_trackers
+        "https://test.adsbynimbus.com/impression_tracker/" shouldBeIn response.trackers.impression
     }
 
     "BidResponse fromJson deserializes the duration field" {
         response.duration shouldBe 15
+    }
+
+    "BidResponse maintains the deprecated field click_trackers" {
+        "https://test.adsbynimbus.com/click_tracker/" shouldBeIn response.click_trackers
+    }
+
+    "BidResponse maintains the deprecated field impression_trackers" {
+        "https://test.adsbynimbus.com/impression_tracker/" shouldBeIn response.impression_trackers
     }
 })


### PR DESCRIPTION
## Changes

- Updated the Kotlin models to allow for adding and deserializing arbitrary values in the ext field.
- Added ext field to all OpenRTB objects
- Updated defaults of BidResponse to match new Nimbus rules omitting fields in certain scenarios