### PR TITLE
Updated Kotlin to 1.7.10 with support for 1.5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,3 @@
-val clean by tasks.registering(Delete::class) {
-    delete(buildDir)
+plugins {
+    base
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dkotlin.daemon.jvm.options="-Xmx2g -XX:+UseParallelGC"
+org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx2g,XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true
@@ -23,13 +23,10 @@ android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 
 ## Kotlin Build Settings
-
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx2g -XX:+UseParallelGC
 kotlin.incremental.multiplatform=true
-kotlin.mpp.enableGranularSourceSetsMetadata=true
 kotlin.mpp.stability.nowarn=true
-kotlin.native.enableDependencyPropagation=false
 # The following disables warnings for targets not supported by the current dev platform
 kotlin.native.ignoreDisabledTargets=true
 kotlin.stdlib.default.dependency=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,13 +1,16 @@
 [versions]
-android = "7.0.3" # Do Not Update this until Kotlin Updated to 1.6.10
-android-buildtools = "32.0.0"
-dokka = "1.6.10"
-kotest = "5.2.3"
+android = "7.2.2"
+android-buildtools = "33.0.0"
+kotest = "5.4.1"
+kotlin = "1.7.10"
 serialization = "1.3.1"
 
 [plugins]
 android = { id = "com.android.library", version.ref = "android" }
-dokka = { id = "org.jetbrains.dokka", version.ref = "dokka" }
+dokka = { id = "org.jetbrains.dokka", version.ref = "kotlin" }
+kotlin-cocoapods = { id = "org.jetbrains.kotlin.native.cocoapods", version.ref = "kotlin" }
+kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
+kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotest = { id = "io.kotest.multiplatform", version.ref = "kotest" }
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,15 +1,16 @@
-@file:Suppress("DSL_SCOPE_VIOLATION")
+@file:Suppress("DSL_SCOPE_VIOLATION", "UnstableApiUsage")
 
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {
     alias(libs.plugins.android)
-    kotlin("multiplatform")
+    alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.kotest)
-    kotlin("native.cocoapods")
+    alias(libs.plugins.kotlin.cocoapods)
     alias(libs.plugins.dokka)
-    kotlin("plugin.serialization")
+    alias(libs.plugins.kotlin.serialization)
     `maven-publish`
 }
 
@@ -32,9 +33,6 @@ kotlin {
     explicitApi()
 
     android {
-        compilations.all {
-            kotlinOptions.jvmTarget = "1.8"
-        }
         publishLibraryVariants("release")
     }
 
@@ -74,7 +72,11 @@ kotlin {
     }
     sourceSets {
         configureEach {
-            languageSettings.optIn("kotlinx.serialization.ExperimentalSerializationApi")
+            languageSettings {
+                apiVersion = "1.5"
+                languageVersion = "1.5"
+                optIn("kotlinx.serialization.ExperimentalSerializationApi")
+            }
         }
         val commonMain by getting {
             dependencies {
@@ -120,6 +122,7 @@ tasks.withType<Test> {
 }
 
 tasks.withType<DokkaTask>().configureEach {
+    notCompatibleWithConfigurationCache("Dokka does not support it yet")
     moduleName.set("nimbus-openrtb")
 
     dokkaSourceSets {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,12 +6,6 @@ pluginManagement {
         mavenCentral()
         gradlePluginPortal()
     }
-    plugins {
-        val kotlin = "1.5.31"
-        kotlin("multiplatform") version(kotlin)
-        kotlin("native.cocoapods") version(kotlin)
-        kotlin("plugin.serialization") version(kotlin)
-    }
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
## Changes

- Updated Kotlin to 1.7.10 with backwards compatibility to 1.5

## Updated Dependencies

- Android Build Tools: 33.0.0
- Android Gradle Plugin: 7.2.2
- Dokka: 1.7.10
- Gradle: 7.5.1
- Kotlin: 1.7.10
- Kotest: 5.4.1
