### PR TITLE
Updated Kotlin build and repository information

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-workflows/ @timehop/nimbus-admins
+workflows/ @timehop/nimbus-admin

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+workflows/ @timehop/nimbus-admins

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -2,15 +2,16 @@ name: Kotlin
 
 on:
   pull_request:
-    branches:
-      - main
     paths:
       - 'kotlin/**'
       - '.github/workflows/kotlin*'
 
   push:
-    tags-ignore:
-      - '**'
+    branches:
+      - main
+    paths:
+      - 'kotlin/**'
+      - '.github/workflows/kotlin*'
 
   release:
     types: [published]
@@ -18,8 +19,30 @@ on:
 jobs:
 
   build:
-    name: Build, test, and optionally publish Android OpenRTB
     runs-on: macos-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: 11
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+
+      - name: Test
+        run: ./gradlew build --no-daemon
+
+  publish:
+    if: github.repository == 'timehop/nimbus-openrtb' && github.event_name == 'release'
+    runs-on: macos-latest
+    needs: build
     env:
       ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.NIMBUS_MOBILE_AWS_ACCESS_KEY }}
       ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.NIMBUS_MOBILE_AWS_SECRET_KEY }}
@@ -37,26 +60,9 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 11
-          cache: 'gradle'
 
-      - name: Cache Kotlin packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('settings.gradle.kts') }}
-            ${{ runner.os }}-konan-
-
-      - name: Fix NDK Bug
-        run: echo "ndk.dir=$ANDROID_HOME/ndk-bundle" > local.properties
-
-      - name: Build
-        run: ./gradlew test
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
 
       - name: Publish
-        if: success() && github.event_name == 'release'
-        run: ./gradlew publish
-
-      - name: Stop Gradle Daemon for Caching
-        run: ./gradlew --stop
+        run: ./gradlew publish --no-daemon

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -19,6 +19,7 @@ on:
 jobs:
 
   build:
+    name: Build Kotlin Multiplatform
     runs-on: macos-latest
     concurrency:
       group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,10 +37,20 @@ jobs:
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
+      - name: Cache Kotlin packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+            ${{ runner.os }}-konan-
+
       - name: Test
-        run: ./gradlew build --no-daemon
+        run: ./gradlew test publishToMavenLocal --no-daemon
 
   publish:
+    name: Publish Kotlin Multiplatform
     if: github.repository == 'timehop/nimbus-openrtb' && github.event_name == 'release'
     runs-on: macos-latest
     needs: build
@@ -63,6 +74,15 @@ jobs:
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
+
+      - name: Cache Kotlin packages
+        uses: actions/cache@v3
+        with:
+          path: ~/.konan
+          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
+            ${{ runner.os }}-konan-
 
       - name: Publish
         run: ./gradlew publish --no-daemon

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Timehop
+Copyright (c) 2022 Timehop
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -6,8 +6,9 @@ Platform specific implementations of Nimbus OpenRTB Request and Response models
 
 ### Supported Platforms
 
-- [![Kotlin](https://github.com/timehop/nimbus-openrtb/actions/workflows/kotlin.yml/badge.svg)](kotlin)
+- [![C#](https://github.com/timehop/nimbus-openrtb/actions/workflows/csharp.yml/badge.svg)](csharp)
 - [![Go](https://github.com/timehop/nimbus-openrtb/actions/workflows/go.yml/badge.svg)](go)
+- [![Kotlin](https://github.com/timehop/nimbus-openrtb/actions/workflows/kotlin.yml/badge.svg)](kotlin)
 - [S2S](https://github.com/timehop/nimbus-openrtb/wiki/Nimbus-S2S-Documentation)
 
 ### Adding New Platforms

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project-wide Gradle settings.
-org.gradle.jvmargs=-Xmx4g -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx2g,XX:+UseParallelGC
+org.gradle.jvmargs=-Xmx6g -XX:+UseParallelGC -Dkotlin.daemon.jvm.options=-Xmx2g,XX:+UseParallelGC
 org.gradle.caching=true
 org.gradle.configureondemand=true
 org.gradle.parallel=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 android = "7.2.2"
 android-buildtools = "33.0.0"
-kotest = "5.4.1"
+kotest = "5.4.2"
 kotlin = "1.7.10"
 serialization = "1.3.1"
 

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -142,12 +142,12 @@ publishing {
             setUrl("s3://adsbynimbus-public/android/sdks")
             credentials(AwsCredentials::class)
         }
-        System.getenv("GITHUB_REPOSITORY")?.let {
+        providers.environmentVariable("GITHUB_REPOSITORY").map {
             maven {
                 name = "github"
                 url = uri("https://maven.pkg.github.com/$it")
                 credentials(PasswordCredentials::class)
             }
-        }
+        }.orNull
     }
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,7 +1,6 @@
 @file:Suppress("DSL_SCOPE_VIOLATION", "UnstableApiUsage")
 
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.tasks.KotlinNativeCompile
 import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 
 plugins {


### PR DESCRIPTION
## Changes

- Updated the Kotlin workflow to be split into a build and publish job and use gradle build action
- Updated repository information to include code owners and the c# build
- Updated Kotest to 5.4.2
- Updated gradle build to use 6 gig of memory for builds