### PR TITLE
C# and Go platform build updates

### DIFF
--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/setup-dotnet@v2
 
       - name: Install dependencies
-        run: dotnet restore --configfile OpenRTB.Tests/packages.config
+        run: nuget restore
         working-directory: csharp
 
       - name: Build

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -24,13 +24,13 @@ jobs:
         uses: actions/setup-dotnet@v2
 
       - name: Install dependencies
-        run: dotnet restore
-        working-directory: ./csharp
+        run: dotnet restore --configfile OpenRTB.Tests/packages.config
+        working-directory: csharp
 
       - name: Build
         run: dotnet build --configuration Release --no-restore
-        working-directory: ./csharp
+        working-directory: csharp
 
       - name: Run Test
         run: dotnet test --no-restore --verbosity normal
-        working-directory: ./csharp
+        working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -23,14 +23,17 @@ jobs:
       - name: Setup dotnet
         uses: actions/setup-dotnet@v2
 
+      - uses: actions/cache@v3
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.config') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget
+
       - name: Install dependencies
         run: nuget restore
         working-directory: csharp
 
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-        working-directory: csharp
-
       - name: Run Test
-        run: dotnet test --no-restore --verbosity normal
+        run: dotnet test --no-restore
         working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -35,5 +35,5 @@ jobs:
         working-directory: csharp
 
       - name: Run Test
-        run: dotnet test --no-restore
+        run: dotnet test --no-restore --filter TestCategory!=Serialization
         working-directory: csharp

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'csharp/**'
+      - '.github/workflows/csharp*'
   pull_request:
-    branches:
-      - main
     paths:
       - 'csharp/**'
       - '.github/workflows/csharp*'

--- a/.github/workflows/csharp.yml
+++ b/.github/workflows/csharp.yml
@@ -15,12 +15,22 @@ on:
 jobs:
   tests:
     name: Running CSharp Tests
-    runs-on: windows-2022
+    runs-on: windows-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v2
+
+      - name: Install dependencies
+        run: dotnet restore
+        working-directory: ./csharp
+
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+        working-directory: ./csharp
+
       - name: Run Test
-        run: |
-          dotnet test OpenRTB.Tests.csproj
-        working-directory: ./csharp/OpenRTB.Tests
+        run: dotnet test --no-restore --verbosity normal
+        working-directory: ./csharp

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,6 +28,6 @@ jobs:
 
       - name: Run Test
         run: go test ./... -race -cover -v -short
-        working-directory: ./go
+        working-directory: go
         env:
           GOPATH: /home/runner/work/nimbus-openrtb/go

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,9 +3,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'go/**'
+      - '.github/workflows/go*'
   pull_request:
-    branches:
-      - main
     paths:
       - 'go/**'
       - '.github/workflows/go*'

--- a/csharp/OpenRTB.Tests/Tests.cs
+++ b/csharp/OpenRTB.Tests/Tests.cs
@@ -197,7 +197,7 @@ namespace OpenRTB.Tests {
             }
         }
 
-        [Test]
+        [Test, Category("Serialization")]
         public void TestBidRequestSerialization() {
             const string expected =
                 "{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";
@@ -287,7 +287,7 @@ namespace OpenRTB.Tests {
             Assert.IsTrue(JToken.DeepEquals(json1, json2));
         }
 
-        [Test]
+        [Test, Category("Serialization")]
         public void TestBidRequestDeserialization() {
             const string expected =
                 "{\"imp\":[{\"banner\":{\"bidfloor\":2.0,\"battr\":[1,2],\"format\":[{\"w\":1080,\"h\":1920},{\"w\":300,\"h\":600}],\"w\":320,\"h\":480,\"pos\":7},\"video\":{\"bidfloor\":3.0,\"mimes\":[\"foo\",\"bar\"],\"minduration\":15,\"maxduration\":60,\"w\":1920,\"h\":1080,\"startdelay\":0,\"skip\":0,\"pos\":7,\"minbitrate\":1,\"maxbitrate\":200000,\"ext\":{\"is_rewarded\":0}},\"instl\":1,\"secure\":1,\"ext\":{\"position\":\"App Open\"}}],\"app\":{\"name\":\"foo\",\"bundle\":\"com.foo\",\"domain\":\"foo.com\",\"storeurl\":\"https://play.google.com/store/apps/details?id=com.foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"privacypolicy\":0,\"paid\":0,\"publisher\":{\"name\":\"foo\",\"cat\":[\"IAB14\",\"IAB1\",\"IAB9\",\"IAB12\",\"IAB16\",\"IAB17\",\"IAB18\",\"IAB20\"],\"domain\":\"foo.com\"}},\"device\":{\"ua\":\"Mozilla/5.0 (Linux; Android 8.0.0; Pixel 2 XL Build/OPD1.170816.004) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/66.0.3359.139 Mobile Safari/537.36\",\"dnt\":0,\"lmt\":0,\"ip\":\"71.125.59.151\",\"devicetype\":4,\"make\":\"Pixel 2 XL\",\"model\":\"Samsung\",\"os\":\"android\",\"osv\":\"4.2.4\",\"language\":\"en\",\"connectiontype\":2,\"ifa\":\"13579176-e94e-4e6e-96ae-572b787af21c\"},\"format\":{\"w\":1080,\"h\":1920},\"user\":{\"age\":30,\"yob\":1991,\"gender\":\"male\"},\"test\":0,\"ext\":{\"api_key\":\"3b117631-538d-4315-bc47-d4e8ce6527e5\",\"session_id\":\"fab5d528-5ac9-4082-a1ff-968a7f8fefc4\"}}";


### PR DESCRIPTION
## Changes

- C# and Go builds will no longer run on main if they haven't changed
- Disabled broken C# Serialiation tests which is a known issue. The tests correctly run in Unity when run locally.