### PR TITLE
Added Facebook and Unity buyer id fields

### DIFF
--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/User.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/User.kt
@@ -45,20 +45,22 @@ public class User(
      * User extension object used by Nimbus
      *
      * @property consent Publisher provided GDPR consent string
-     * @property did_consent 1 if the user has consented to data tracking, 0 if the user has opted
-     *                       out of data tracking.
+     * @property facebook_buyeruid String token provided by the Facebook Audience Network to include FAN demand in
+     *                             the auction.
      * @property unity_buyeruid String token provided by the Unity Ads SDK to include Unity demand
      *                          in the auction. Token is initialized when UnityAds is initialized
      *                          and the token and campaign is refreshed after the ad playback has
      *                          started.
+     * @property vungle_buyeruid String token provided by the Vungle SDK to include Vungle in the auction.
      * @property eids Collection of external user ids
      */
     @Serializable
     public class Extension(
         @JvmField @SerialName("consent") public var consent: String? = null,
-        @JvmField @SerialName("did_consent") public var did_consent: Byte? = null,
+        @JvmField @SerialName("facebook_buyeruid") public var facebook_buyeruid: String? = null,
         @JvmField @SerialName("unity_buyeruid") public var unity_buyeruid: String? = null,
-        @JvmField @SerialName("eids") public var eids: Set<EID>? = null
+        @JvmField @SerialName("vungle_buyeruid") public var vungle_buyeruid: String? = null,
+        @JvmField @SerialName("eids") public var eids: Set<EID>? = null,
     )
 }
 

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
@@ -49,15 +49,14 @@ public class BidResponse(
     @JvmField @SerialName("placement_id") public val placement_id: String? = null,
     @JvmField @SerialName("is_mraid") public val is_mraid: Byte = 0,
     @JvmField @SerialName("position") public val position: String,
-    @JvmField @SerialName("trackers") public val trackers: Map<String, Array<String>> =
-        emptyMap<String, Array<String>>().withDefault { emptyArray() },
+    @JvmField @SerialName("trackers") public val trackers: Map<String, Array<String>> = emptyMap(),
     @JvmField @SerialName("duration") public val duration: Int = 0,
 ) {
 
     /** Urls to fire a request to when an impression is registered */
-    public val impression_trackers: Array<String> by trackers
+    public val impression_trackers: Array<String>? by trackers
     /** Urls to fire a request to when a click is registered */
-    public val click_trackers: Array<String> by trackers
+    public val click_trackers: Array<String>? by trackers
 
     public companion object {
         /** Decodes a BidResponse from a Json string using the built in serializer */

--- a/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
+++ b/kotlin/src/commonTest/kotlin/com/adsbynimbus/openrtb/response/DeserializationTest.kt
@@ -2,7 +2,6 @@ package com.adsbynimbus.openrtb.response
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldBeIn
-import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.shouldBe
 
 const val testJson = """
@@ -79,11 +78,11 @@ class DeserializationTest : StringSpec({
     }
 
     "BidResponse fromJson deserializes click_trackers" {
-        "https://test.adsbynimbus.com/click_tracker/" shouldBeIn response.click_trackers
+        "https://test.adsbynimbus.com/click_tracker/" shouldBeIn response.click_trackers!!
     }
 
     "BidResponse fromJson deserializes impression_trackers" {
-        "https://test.adsbynimbus.com/impression_tracker/" shouldBeIn response.impression_trackers
+        "https://test.adsbynimbus.com/impression_tracker/" shouldBeIn response.impression_trackers!!
     }
 
     "BidResponse fromJson deserializes the duration field" {


### PR DESCRIPTION
## Changes

- Added facebook_buyeruid and vungle_buyeruid fields to the user extension object.
- Removed deprecated did_consent field
- Updated types of tracker properties to reflect nullability