### PR TITLE
Updated Kotlin build to support new version mechanism

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -51,11 +51,12 @@ jobs:
 
       - name: Set Version from Tag Name
         id: tag_name
+        if: github.event_name == 'release'
         run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
 
       - name: Test
         env:
-          ORG_GRADLE_PROJECT_version: ${{ steps.tag_name.outputs.VERSION }}
+          ORG_GRADLE_PROJECT_version: ${{ steps.tag_name.outputs.VERSION || '0.0.1' }}
         run: ./gradlew test publishToMavenLocal
 
       - name: Publish

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -21,42 +21,7 @@ jobs:
   build:
     name: Build Kotlin Multiplatform
     runs-on: macos-latest
-    concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
-      cancel-in-progress: true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup Java
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: 11
-
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-
-      - name: Cache Kotlin packages
-        uses: actions/cache@v3
-        with:
-          path: ~/.konan
-          key: ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
-            ${{ runner.os }}-konan-
-
-      - name: Test
-        run: ./gradlew test publishToMavenLocal --no-daemon
-
-  publish:
-    name: Publish Kotlin Multiplatform
-    if: github.repository == 'timehop/nimbus-openrtb' && github.event_name == 'release'
-    runs-on: macos-latest
-    needs: build
     env:
-      ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.NIMBUS_MOBILE_AWS_ACCESS_KEY }}
-      ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.NIMBUS_MOBILE_AWS_SECRET_KEY }}
       ORG_GRADLE_PROJECT_githubUsername: ${{ github.actor }}
       ORG_GRADLE_PROJECT_githubPassword: ${{ github.token }}
     concurrency:
@@ -84,5 +49,19 @@ jobs:
             ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
             ${{ runner.os }}-konan-
 
+      - name: Set Version from Tag Name
+        id: tag_name
+        run: echo ::set-output name=version::${GITHUB_REF/refs\/tags\/v/}
+
+      - name: Test
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ steps.tag_name.outputs.VERSION }}
+        run: ./gradlew test publishToMavenLocal
+
       - name: Publish
-        run: ./gradlew publish --no-daemon
+        if: github.repository == 'timehop/nimbus-openrtb' && github.event_name == 'release'
+        env:
+          ORG_GRADLE_PROJECT_version: ${{ steps.tag_name.outputs.VERSION }}
+          ORG_GRADLE_PROJECT_awsAccessKey: ${{ secrets.NIMBUS_MOBILE_AWS_ACCESS_KEY }}
+          ORG_GRADLE_PROJECT_awsSecretKey: ${{ secrets.NIMBUS_MOBILE_AWS_SECRET_KEY }}
+        run: ./gradlew publish

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,0 @@
-plugins {
-    base
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,6 +10,9 @@ org.gradle.parallel=true
 #org.gradle.unsafe.configuration-cache-problems=warn
 #org.gradle.unsafe.configuration-cache.max-problems=5
 
+group=com.adsbynimbus.openrtb
+version=0.0.1
+
 ## Android Build Settings
 
 android.defaults.buildfeatures.aidl=false

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -13,6 +13,9 @@ plugins {
     `maven-publish`
 }
 
+val androidOnly = providers.gradleProperty("android.injected.attribution.file.location")
+    .map { it.contains("android") }.getOrElse(false)
+
 group = "com.adsbynimbus.openrtb"
 version = (System.getenv("GITHUB_REF") ?: "0.0.1").split("/").last().let {
     if (it.startsWith("v")) it.substring(1) else it
@@ -36,37 +39,39 @@ kotlin {
     }
 
     // Apple deployments in rough dependency order
-    val xcf = XCFramework()
+    if (!androidOnly) {
+        val xcf = XCFramework()
 
-    cocoapods {
-        summary = "Nimbus OpenRTB API Module"
-        homepage = "https://www.github.com/timehop/nimbus-openrtb"
-        license = "MIT"
-        authors = "Ads By Nimbus"
-        ios.deploymentTarget = "10.0"
-        framework {
-            baseName = "NimbusOpenRTB"
+        cocoapods {
+            summary = "Nimbus OpenRTB API Module"
+            homepage = "https://www.github.com/timehop/nimbus-openrtb"
+            license = "MIT"
+            authors = "Ads By Nimbus"
+            ios.deploymentTarget = "10.0"
+            framework {
+                baseName = "NimbusOpenRTB"
+            }
         }
-    }
 
-    iosX64 {
-        binaries.framework {
-            xcf.add(this)
+        iosX64 {
+            binaries.framework {
+                xcf.add(this)
+            }
         }
-    }
-    iosArm64 {
-        binaries.framework {
-            xcf.add(this)
+        iosArm64 {
+            binaries.framework {
+                xcf.add(this)
+            }
         }
-    }
-    iosSimulatorArm64 {
-        binaries.framework {
-            xcf.add(this)
+        iosSimulatorArm64 {
+            binaries.framework {
+                xcf.add(this)
+            }
         }
-    }
-    tvos {
-        binaries.framework {
-            xcf.add(this)
+        tvos {
+            binaries.framework {
+                xcf.add(this)
+            }
         }
     }
     sourceSets {
@@ -95,23 +100,25 @@ kotlin {
                 implementation(libs.bundles.test.android)
             }
         }
-        val iosX64Main by getting
-        val iosArm64Main by getting
-        val iosSimulatorArm64Main by getting
-        val iosMain by creating {
-            dependsOn(commonMain)
-            iosX64Main.dependsOn(this)
-            iosArm64Main.dependsOn(this)
-            iosSimulatorArm64Main.dependsOn(this)
-        }
-        val iosX64Test by getting
-        val iosArm64Test by getting
-        val iosSimulatorArm64Test by getting
-        val iosTest by creating {
-            dependsOn(commonTest)
-            iosX64Test.dependsOn(this)
-            iosArm64Test.dependsOn(this)
-            iosSimulatorArm64Test.dependsOn(this)
+        if (!androidOnly) {
+            val iosX64Main by getting
+            val iosArm64Main by getting
+            val iosSimulatorArm64Main by getting
+            val iosMain by creating {
+                dependsOn(commonMain)
+                iosX64Main.dependsOn(this)
+                iosArm64Main.dependsOn(this)
+                iosSimulatorArm64Main.dependsOn(this)
+            }
+            val iosX64Test by getting
+            val iosArm64Test by getting
+            val iosSimulatorArm64Test by getting
+            val iosTest by creating {
+                dependsOn(commonTest)
+                iosX64Test.dependsOn(this)
+                iosArm64Test.dependsOn(this)
+                iosSimulatorArm64Test.dependsOn(this)
+            }
         }
     }
 }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -16,11 +16,6 @@ plugins {
 val androidOnly = providers.gradleProperty("android.injected.attribution.file.location")
     .map { it.contains("android") }.getOrElse(false)
 
-group = "com.adsbynimbus.openrtb"
-version = (System.getenv("GITHUB_REF") ?: "0.0.1").split("/").last().let {
-    if (it.startsWith("v")) it.substring(1) else it
-}
-
 android {
     buildToolsVersion = libs.versions.android.buildtools.get()
     compileSdk = 31
@@ -149,12 +144,12 @@ publishing {
             setUrl("s3://adsbynimbus-public/android/sdks")
             credentials(AwsCredentials::class)
         }
-        providers.environmentVariable("GITHUB_REPOSITORY").map {
+        providers.environmentVariable("GITHUB_REPOSITORY").orNull?.let {
             maven {
                 name = "github"
                 url = uri("https://maven.pkg.github.com/$it")
                 credentials(PasswordCredentials::class)
             }
-        }.orNull
+        }
     }
 }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
@@ -4,7 +4,6 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmField
-import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
 /**

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/request/BidRequest.kt
@@ -77,12 +77,12 @@ public class BidRequest(
         }
 
         /** Encodes a BidRequest to a Json string using the built in serializer */
-        @JvmStatic @JvmOverloads
+        @JvmStatic
         public fun BidRequest.toJson(jsonSerializer: Json = lenientSerializer): String =
             jsonSerializer.encodeToString(serializer(), this)
 
         /** Decodes a BidRequest from a Json string using the built in serializer */
-        @JvmStatic @JvmOverloads
+        @JvmStatic
         public fun fromJson(json: String, jsonSerializer: Json = lenientSerializer): BidRequest =
             jsonSerializer.decodeFromString(serializer(), json)
     }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
@@ -3,6 +3,7 @@ package com.adsbynimbus.openrtb.response
 import com.adsbynimbus.openrtb.request.BidRequest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmOverloads
@@ -60,10 +61,17 @@ public class BidResponse(
 
     public companion object {
         /** Decodes a BidResponse from a Json string using the built in serializer */
-        @JvmStatic @JvmOverloads
+        @JvmStatic
         public fun fromJson(
             json: String,
             jsonSerializer: Json = BidRequest.lenientSerializer,
         ): BidResponse = jsonSerializer.decodeFromString(serializer(), json)
+
+        /** Encodes a BidResponse to a Json string using the built in serializer */
+        @JvmStatic
+        public fun toJson(
+            response: BidResponse,
+            jsonSerializer: Json = BidRequest.lenientSerializer,
+        ): String = jsonSerializer.encodeToString(serializer(), response)
     }
 }

--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
@@ -3,10 +3,8 @@ package com.adsbynimbus.openrtb.response
 import com.adsbynimbus.openrtb.request.BidRequest
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlin.jvm.JvmField
-import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
 /**


### PR DESCRIPTION
## Changes

- Added flag to disbale iOS builds if used in an Android only environment
- Version is now set by the gradle properties with a build override
- Added a utility toJson method for encoding BidResponse
- Removed JvmOverloads from serialize helpers, Java does not use Kotlin Serialization