### PR TITLE
Removed BidResponse extension

### DIFF
--- a/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
+++ b/kotlin/src/commonMain/kotlin/com/adsbynimbus/openrtb/response/BidResponse.kt
@@ -55,7 +55,6 @@ public class BidResponse(
     @JvmField @SerialName("duration") public val duration: Int = 0,
     @JvmField @SerialName("exp") public val exp: Int = -1,
     @JvmField @SerialName("external_notifications") public val external_notifications: Map<String, String> = emptyMap(),
-    @JvmField @SerialName("ext") public val ext: Extension = Extension(),
 ) {
     /** Urls to fire a request to when an impression is registered */
     public val impression_trackers: Array<String>? get() = trackers["impression_trackers"]
@@ -81,14 +80,4 @@ public class BidResponse(
             jsonSerializer: Json = BidRequest.lenientSerializer,
         ): String = jsonSerializer.encodeToString(serializer(), response)
     }
-
-    /**
-     * BidResponse Extension object from Nimbus
-     *
-     * @property use_new_renderer Set to false if Nimbus has determined the creative should be rendered using IMA SDK
-     */
-    @Serializable
-    public class Extension(
-        @JvmField @SerialName("use_new_renderer") public val use_new_renderer: Boolean = true,
-    )
 }

--- a/kotlin/src/commonTest/kotlin/BidResponseTest.kt
+++ b/kotlin/src/commonTest/kotlin/BidResponseTest.kt
@@ -7,7 +7,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldStartWith
 
-private fun testJson(ext: String = "") = """
+const val testResponse = """
 {
   "type": "native",
   "auction_id": "d07668d6-35ba-4870-a3cd-02b18fec1a12",
@@ -34,7 +34,6 @@ private fun testJson(ext: String = "") = """
     "win_response": "https://test.adsbynimbus.com/win_response/",
     "loss_response": "https://test.adsbynimbus.com/loss_response/auctionPrice=[AUCTION_PRICE]&auctionMinToWin=[AUCTION_MIN_TO_WIN]&winningSource=[WINNING_SOURCE]"
   }
-  $ext
 }
 """
 
@@ -43,7 +42,7 @@ class BidResponseTest : StringSpec({
     lateinit var response: BidResponse
 
     beforeTest {
-        response = BidResponse.fromJson(testJson())
+        response = BidResponse.fromJson(testResponse)
     }
 
     "BidResponse fromJson deserializes the type field" {
@@ -108,22 +107,6 @@ class BidResponseTest : StringSpec({
 
     "BidResponse fromJson deserializes win urls" {
         response.win_response shouldBe "https://test.adsbynimbus.com/win_response/"
-    }
-
-    "BidResponse fromJson deserializes use_new_renderer" {
-        // if missing, default is true
-        response.ext.use_new_renderer shouldBe true
-        BidResponse.fromJson(testJson("""
-            ,"ext": {
-                "use_new_renderer": true
-            }
-        """.trimIndent())).ext.use_new_renderer shouldBe true
-        BidResponse.fromJson(
-            testJson("""
-            ,"ext": {
-                "use_new_renderer": false
-            }
-        """.trimIndent())).ext.use_new_renderer shouldBe false
     }
 
     "BidResponse fromJson deserializes loss urls" {


### PR DESCRIPTION
## Changes

Removes the no longer used `use_new_renderer` property and associated Extension from BidResponse