### PR TITLE
Android 8.10.1, Dokka 2.0.0, Gradle 8.14.3, and Kotlin 2.1.21 update

### DIFF
--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -80,3 +80,10 @@ jobs:
         env:
           ORG_GRADLE_PROJECT_version: ${{ steps.tag_name.outputs.VERSION }}
         run: ./gradlew publish
+
+      - name: Upload build reports
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: build-reports
+          path: '**/build/reports/'

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -53,9 +53,6 @@ jobs:
         with:
           path: ~/.konan
           key: ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-konan-${{ hashFiles('**/*.versions.toml') }}
-            ${{ runner.os }}-konan-
 
       - name: Set Version to Tag Name
         id: tag_name

--- a/.github/workflows/kotlin.yml
+++ b/.github/workflows/kotlin.yml
@@ -40,11 +40,13 @@ jobs:
       - name: Setup Java
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: 17
+          distribution: 'zulu'
+          java-version: 21
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-encryption-key: ${{ secrets.GRADLE_ENCRYPTION_KEY }}
 
       - name: Cache Kotlin packages
         uses: actions/cache@v4

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,6 +18,10 @@ android.defaults.buildfeatures.shaders=false
 android.library.defaults.buildfeatures.androidresources=false
 android.useAndroidX=true
 
+# Dokka
+org.jetbrains.dokka.experimental.gradle.pluginMode=V2Enabled
+org.jetbrains.dokka.experimental.gradle.pluginMode.noWarn=true
+
 # Kotlin Build Settings
 kotlin.code.style=official
 kotlin.daemon.jvmargs=-Xmx1536m

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,6 +16,7 @@ version=development
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.library.defaults.buildfeatures.androidresources=false
+android.javaCompile.suppressSourceTargetDeprecationWarning=true
 android.useAndroidX=true
 
 # Dokka

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,28 +1,28 @@
 # Project-wide Gradle settings.
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx6g -Xms6g -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError
+org.gradle.jvmargs=-Xmx5g -XX:+UseParallelGC -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
-org.gradle.configureondemand=true
-org.gradle.parallel=true
-
-# The configuration cache remains disabled due to publishing tasks not working with it
 org.gradle.configuration-cache=true
 org.gradle.configuration-cache.parallel=true
 org.gradle.configuration-cache-problems=warn
 org.gradle.configuration-cache.max-problems=5
+org.gradle.configureondemand=true
+org.gradle.parallel=true
 
+# Versioning
 group=com.adsbynimbus.openrtb
 version=development
 
-## Android Build Settings
+# Android Build Settings
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.library.defaults.buildfeatures.androidresources=false
 android.useAndroidX=true
 
-## Kotlin Build Settings
+# Kotlin Build Settings
 kotlin.code.style=official
-kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -Xmx6g -Xms6g -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=320m -XX:+HeapDumpOnOutOfMemoryError
+kotlin.daemon.jvmargs=-Xmx1536m
 kotlin.incremental.multiplatform=true
 kotlin.incremental.native=true
-kotlin.native.ignoreDisabledTargets=true
+kotlin.kmp.isolated-projects.support=enable
+kotlin.native.enableKlibsCrossCompilation=true
 kotlin.stdlib.default.dependency=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-android = "8.9.2"
+android = "8.10.1"
 dokka = "1.9.20"
 kotest = "6.0.0.M3"
 kotlin = "2.1.20"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 android = "8.10.1"
-dokka = "1.9.20"
+dokka = "2.0.0"
 kotest = "6.0.0.M3"
 kotlin = "2.1.21"
 serialization = { require = "[1.5.1, )", prefer = "1.7.3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 android = "8.10.1"
 dokka = "1.9.20"
 kotest = "6.0.0.M3"
-kotlin = "2.1.20"
+kotlin = "2.1.21"
 serialization = { require = "[1.5.1, )", prefer = "1.7.3" }
 
 [plugins]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/integration-tests/settings.gradle.kts
+++ b/integration-tests/settings.gradle.kts
@@ -4,9 +4,9 @@ pluginManagement {
     repositories {
         google {
             mavenContent {
-                includeGroupAndSubgroups("androidx")
-                includeGroupAndSubgroups("com.android")
-                includeGroupAndSubgroups("com.google")
+                includeGroupByRegex("androidx.*")
+                includeGroupByRegex("com.android.*")
+                includeGroupByRegex("com.google.*")
             }
         }
         mavenCentral()
@@ -19,9 +19,9 @@ dependencyResolutionManagement {
         mavenLocal()
         google {
             mavenContent {
-                includeGroupAndSubgroups("androidx")
-                includeGroupAndSubgroups("com.android")
-                includeGroupAndSubgroups("com.google")
+                includeGroupByRegex("androidx.*")
+                includeGroupByRegex("com.android.*")
+                includeGroupByRegex("com.google.*")
             }
         }
         mavenCentral()

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTask
-import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
+import org.jetbrains.kotlin.gradle.dsl.*
 
 plugins {
     alias(libs.plugins.android)
@@ -23,6 +22,12 @@ android {
 kotlin {
     explicitApi()
 
+    compilerOptions {
+        apiVersion = KotlinVersion.KOTLIN_1_8
+        languageVersion = KotlinVersion.KOTLIN_1_8
+        optIn = listOf("kotlinx.serialization.ExperimentalSerializationApi")
+    }
+
     androidTarget {
         compilations.configureEach {
             compileTaskProvider.configure {
@@ -36,13 +41,6 @@ kotlin {
     iosSimulatorArm64()
 
     sourceSets {
-        configureEach {
-            languageSettings {
-                apiVersion = KotlinVersion.KOTLIN_1_8.version
-                languageVersion = KotlinVersion.KOTLIN_1_8.version
-                optIn("kotlinx.serialization.ExperimentalSerializationApi")
-            }
-        }
         commonMain.dependencies {
             implementation(libs.serialization.json)
         }

--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,4 +1,3 @@
-import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.dsl.*
 
 plugins {
@@ -14,7 +13,7 @@ android {
     compileSdk = 36
     defaultConfig {
         minSdk = 21
-        consumerProguardFile("src/androidMain/consumer-proguard-rules.pro")
+        consumerProguardFile(layout.projectDirectory.file("src/androidMain/consumer-proguard-rules.pro"))
     }
     namespace = "com.adsbynimbus.openrtb"
 }
@@ -57,15 +56,15 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-tasks.withType<DokkaTask>().configureEach {
+dokka {
     moduleName = "nimbus-openrtb"
-
+    dokkaGeneratorIsolation = ClassLoaderIsolation()
     dokkaSourceSets {
         named("commonMain") {
             sourceLink {
-                localDirectory = layout.projectDirectory.file("src/$name/kotlin").asFile
-                remoteUrl = uri("https://github.com/timehop/nimbus-openrtb/kotlin/src/$name/kotlin").toURL()
+                localDirectory = layout.projectDirectory.dir("src/$name/kotlin")
                 remoteLineSuffix = "#L"
+                remoteUrl("https://github.com/timehop/nimbus-openrtb/kotlin/src/$name/kotlin")
             }
         }
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -14,8 +14,9 @@ pluginManagement {
     }
 }
 
-val androidGradleOverride = with(providers) {
-    gradleProperty("android.studio.version").flatMap { gradleProperty("android.gradle") }
+// Allows Android Gradle Plugin override if build is started from Android Studio or CI
+val androidGradleOverride = providers.gradleProperty("android.gradle").filter {
+    providers.systemProperty("idea.vendor.name").orNull != "JetBrains"
 }
 
 dependencyResolutionManagement {
@@ -30,7 +31,7 @@ dependencyResolutionManagement {
         mavenCentral()
     }
     versionCatalogs.configureEach {
-          if (androidGradleOverride.isPresent) version("android", androidGradleOverride.get())
+        if (androidGradleOverride.isPresent) version("android", androidGradleOverride.get())
     }
 }
 


### PR DESCRIPTION
## Changes

- Updated Dokka to use the new 2.0.0 Gradle plugin
- Optimized Gradle jvm parameters for running multiplatform builds
- Github Actions Kotlin build now uses Zulu JDK 21 and enabled Gradle configuration cache
- Fixed settings.gradle.kts to allow for tests to run using Gradle 7.5.1
- Android Gradle Plugin override disabled for non Android Studio Intellij IDEs, 8.10.1 latest supported plugin
- Consumer proguard file added using configuration cache safe layout API
- Upload test results from Github Actions if not cancelled

## Library Updates

- Android Gradle Plugin: 8.10.1
- Dokka: 2.0.0
- Kotlin: 2.1.21